### PR TITLE
feat(worker): implement ClickHouse persistence for uptime monitoring

### DIFF
--- a/apps/worker/package.json
+++ b/apps/worker/package.json
@@ -8,6 +8,7 @@
     "start": "bun run src/index.ts"
   },
   "dependencies": {
+    "@repo/clickhouse": "workspace:*",
     "@repo/config": "workspace:*",
     "@repo/streams": "workspace:*",
     "axios": "^1.13.2"

--- a/packages/clickhouse/.gitignore
+++ b/packages/clickhouse/.gitignore
@@ -1,0 +1,34 @@
+# dependencies (bun install)
+node_modules
+
+# output
+out
+dist
+*.tgz
+
+# code coverage
+coverage
+*.lcov
+
+# logs
+logs
+_.log
+report.[0-9]_.[0-9]_.[0-9]_.[0-9]_.json
+
+# dotenv environment variable files
+.env
+.env.development.local
+.env.test.local
+.env.production.local
+.env.local
+
+# caches
+.eslintcache
+.cache
+*.tsbuildinfo
+
+# IntelliJ based IDEs
+.idea
+
+# Finder (MacOS) folder config
+.DS_Store

--- a/packages/clickhouse/README.md
+++ b/packages/clickhouse/README.md
@@ -1,0 +1,27 @@
+# @repo/clickhouse
+
+ClickHouse client wrapper used for uptime metrics.
+
+## Configuration
+
+Add the following variables (for example in `packages/config/.env`):
+
+- `CLICKHOUSE_URL` – ClickHouse HTTP endpoint (e.g. `http://localhost:8123`)
+- `CLICKHOUSE_USERNAME` – username (default: `default`)
+- `CLICKHOUSE_PASSWORD` – password (default: empty)
+- `CLICKHOUSE_DATABASE` – database name (default: `default`)
+- `CLICKHOUSE_METRICS_TABLE` – table for uptime events (default: `uptime_checks`)
+
+## Usage
+
+```ts
+import { recordUptimeEvent } from "@repo/clickhouse";
+
+await recordUptimeEvent({
+  websiteId: "abc-123",
+  regionId: "iad",
+  status: "UP",
+  responseTimeMs: 120,
+  checkedAt: new Date(),
+});
+```

--- a/packages/clickhouse/bun.lock
+++ b/packages/clickhouse/bun.lock
@@ -1,0 +1,25 @@
+{
+  "lockfileVersion": 1,
+  "workspaces": {
+    "": {
+      "name": "clickhouse",
+      "devDependencies": {
+        "@types/bun": "latest",
+      },
+      "peerDependencies": {
+        "typescript": "^5",
+      },
+    },
+  },
+  "packages": {
+    "@types/bun": ["@types/bun@1.3.6", "", { "dependencies": { "bun-types": "1.3.6" } }, "sha512-uWCv6FO/8LcpREhenN1d1b6fcspAB+cefwD7uti8C8VffIv0Um08TKMn98FynpTiU38+y2dUO55T11NgDt8VAA=="],
+
+    "@types/node": ["@types/node@25.0.9", "", { "dependencies": { "undici-types": "~7.16.0" } }, "sha512-/rpCXHlCWeqClNBwUhDcusJxXYDjZTyE8v5oTO7WbL8eij2nKhUeU89/6xgjU7N4/Vh3He0BtyhJdQbDyhiXAw=="],
+
+    "bun-types": ["bun-types@1.3.6", "", { "dependencies": { "@types/node": "*" } }, "sha512-OlFwHcnNV99r//9v5IIOgQ9Uk37gZqrNMCcqEaExdkVq3Avwqok1bJFmvGMCkCE0FqzdY8VMOZpfpR3lwI+CsQ=="],
+
+    "typescript": ["typescript@5.9.3", "", { "bin": { "tsc": "bin/tsc", "tsserver": "bin/tsserver" } }, "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw=="],
+
+    "undici-types": ["undici-types@7.16.0", "", {}, "sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw=="],
+  }
+}

--- a/packages/clickhouse/package.json
+++ b/packages/clickhouse/package.json
@@ -1,0 +1,20 @@
+{
+  "name": "@repo/clickhouse",
+  "module": "src/index.ts",
+  "type": "module",
+  "private": true,
+  "exports": {
+    ".": "./src/index.ts"
+  },
+  "dependencies": {
+    "@clickhouse/client": "^1.16.0",
+    "@repo/config": "workspace:*"
+  },
+  "devDependencies": {
+    "@types/bun": "latest",
+    "@repo/typescript-config": "workspace:*"
+  },
+  "peerDependencies": {
+    "typescript": "^5"
+  }
+}

--- a/packages/clickhouse/src/index.ts
+++ b/packages/clickhouse/src/index.ts
@@ -1,0 +1,128 @@
+import { createClient, type ClickHouseClient } from "@clickhouse/client";
+import {
+  CLICKHOUSE_URL,
+  CLICKHOUSE_USERNAME,
+  CLICKHOUSE_PASSWORD,
+  CLICKHOUSE_DATABASE,
+  CLICKHOUSE_METRICS_TABLE,
+} from "@repo/config";
+
+export type UptimeStatus = "UP" | "DOWN";
+
+export interface UptimeEventRecord {
+  websiteId: string;
+  regionId: string;
+  status: UptimeStatus;
+  responseTimeMs?: number;
+  checkedAt: Date;
+}
+
+let client: ClickHouseClient | null = null;
+let schemaReadyPromise: Promise<void> | null = null;
+
+function assertConfig() {
+  if (!CLICKHOUSE_URL) {
+    throw new Error(
+      "CLICKHOUSE_URL is not set. Please configure your ClickHouse HTTP endpoint.",
+    );
+  }
+}
+
+function assertIdentifier(identifier: string) {
+  if (!/^[A-Za-z0-9_]+$/.test(identifier)) {
+    throw new Error(`Invalid ClickHouse identifier: ${identifier}`);
+  }
+}
+
+function getClient(): ClickHouseClient {
+  if (!client) {
+    assertConfig();
+
+    client = createClient({
+      url: CLICKHOUSE_URL,
+      username: CLICKHOUSE_USERNAME || "default",
+      password: CLICKHOUSE_PASSWORD,
+      database: CLICKHOUSE_DATABASE || "default",
+    });
+  }
+
+  return client;
+}
+
+async function ensureSchema(): Promise<void> {
+  if (schemaReadyPromise) {
+    return schemaReadyPromise;
+  }
+
+  schemaReadyPromise = (async () => {
+    assertIdentifier(CLICKHOUSE_METRICS_TABLE);
+
+    const clickhouse = getClient();
+
+    await clickhouse.command({
+      query: `
+        CREATE TABLE IF NOT EXISTS ${CLICKHOUSE_METRICS_TABLE} (
+          website_id String,
+          region_id String,
+          status Enum('UP' = 1, 'DOWN' = 0),
+          response_time_ms Nullable(UInt32),
+          checked_at DateTime64(3, 'UTC'),
+          ingested_at DateTime64(3, 'UTC')
+        )
+        ENGINE = MergeTree
+        ORDER BY (website_id, region_id, checked_at)
+      `,
+    });
+  })();
+
+  return schemaReadyPromise;
+}
+
+export async function recordUptimeEvent(
+  event: UptimeEventRecord,
+): Promise<void> {
+  await ensureSchema();
+  const clickhouse = getClient();
+
+  await clickhouse.insert({
+    table: CLICKHOUSE_METRICS_TABLE,
+    values: [
+      {
+        website_id: event.websiteId,
+        region_id: event.regionId,
+        status: event.status,
+        response_time_ms: event.responseTimeMs ?? null,
+        checked_at: event.checkedAt.toISOString(),
+        ingested_at: new Date().toISOString(),
+      },
+    ],
+    format: "JSONEachRow",
+  });
+}
+
+export async function recordUptimeEvents(
+  events: UptimeEventRecord[],
+): Promise<void> {
+  if (events.length === 0) return;
+
+  await ensureSchema();
+  const clickhouse = getClient();
+  const ingestedAtIso = new Date().toISOString();
+
+  await clickhouse.insert({
+    table: CLICKHOUSE_METRICS_TABLE,
+    values: events.map((event) => ({
+      website_id: event.websiteId,
+      region_id: event.regionId,
+      status: event.status,
+      response_time_ms: event.responseTimeMs ?? null,
+      checked_at: event.checkedAt.toISOString(),
+      ingested_at: ingestedAtIso,
+    })),
+    format: "JSONEachRow",
+  });
+}
+
+export function getClickhouseClient(): ClickHouseClient {
+  return getClient();
+}

--- a/packages/clickhouse/tsconfig.json
+++ b/packages/clickhouse/tsconfig.json
@@ -1,0 +1,9 @@
+{
+  "extends": "@repo/typescript-config/base.json",
+  "compilerOptions": {
+    "outDir": "dist",
+    "rootDir": "."
+  },
+  "include": ["."],
+  "exclude": ["node_modules", "dist"]
+}

--- a/packages/config/src/index.ts
+++ b/packages/config/src/index.ts
@@ -71,6 +71,17 @@ export const REDIS_PASSWORD = getEnvVar("REDIS_PASSWORD", false) || "";
 export const REDIS_HOST = getEnvVar("REDIS_HOST", false) || "localhost";
 export const REDIS_PORT = getEnvVar("REDIS_PORT", false) || "6379";
 
+// ClickHouse (optional - only required when using ClickHouse features)
+export const CLICKHOUSE_URL = getEnvVar("CLICKHOUSE_URL", false) || "";
+export const CLICKHOUSE_USERNAME =
+  getEnvVar("CLICKHOUSE_USERNAME", false) || "default";
+export const CLICKHOUSE_PASSWORD =
+  getEnvVar("CLICKHOUSE_PASSWORD", false) || "";
+export const CLICKHOUSE_DATABASE =
+  getEnvVar("CLICKHOUSE_DATABASE", false) || "default";
+export const CLICKHOUSE_METRICS_TABLE =
+  getEnvVar("CLICKHOUSE_METRICS_TABLE", false) || "uptime_checks";
+
 // Server
 import { BACKEND_PORT as DEFAULT_BACKEND_PORT } from "./constants.js";
 export const BACKEND_PORT =
@@ -98,4 +109,9 @@ export const env = {
   REGION_ID,
   WORKER_ID,
   STREAM_NAME,
+  CLICKHOUSE_URL,
+  CLICKHOUSE_USERNAME,
+  CLICKHOUSE_PASSWORD,
+  CLICKHOUSE_DATABASE,
+  CLICKHOUSE_METRICS_TABLE,
 } as const;

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -188,6 +188,9 @@ importers:
 
   apps/worker:
     dependencies:
+      '@repo/clickhouse':
+        specifier: workspace:*
+        version: link:../../packages/clickhouse
       '@repo/config':
         specifier: workspace:*
         version: link:../../packages/config
@@ -250,6 +253,25 @@ importers:
       vitest:
         specifier: ^4.0.17
         version: 4.0.17(@types/node@22.19.6)(jiti@2.6.1)(lightningcss@1.30.2)(yaml@2.8.2)
+
+  packages/clickhouse:
+    dependencies:
+      '@clickhouse/client':
+        specifier: ^1.16.0
+        version: 1.16.0
+      '@repo/config':
+        specifier: workspace:*
+        version: link:../config
+      typescript:
+        specifier: ^5
+        version: 5.9.2
+    devDependencies:
+      '@repo/typescript-config':
+        specifier: workspace:*
+        version: link:../../tooling/typescript-config
+      '@types/bun':
+        specifier: latest
+        version: 1.3.6
 
   packages/config:
     dependencies:
@@ -506,6 +528,13 @@ packages:
 
   '@chevrotain/utils@10.5.0':
     resolution: {integrity: sha512-hBzuU5+JjB2cqNZyszkDHZgOSrUUT8V3dhgRl8Q9Gp6dAj/H5+KILGjbhDpc3Iy9qmqlm/akuOI2ut9VUtzJxQ==}
+
+  '@clickhouse/client-common@1.16.0':
+    resolution: {integrity: sha512-qMzkI1NmV29ZjFkNpVSvGNfA0c7sCExlufAQMv+V+5xtNeYXnRfdqzmBLIQoq6Pf1ij0kw/wGLD3HQrl7pTFLA==}
+
+  '@clickhouse/client@1.16.0':
+    resolution: {integrity: sha512-ThPhoRMsKsf/hmBEgWlUsGxFecsr3i+k3JI8JV0Od7UpH2BSmk9VKMGJoyPCrTL0vPUs5rJH+7o4iCqBF09Xvg==}
+    engines: {node: '>=16'}
 
   '@electric-sql/pglite-socket@0.0.6':
     resolution: {integrity: sha512-6RjmgzphIHIBA4NrMGJsjNWK4pu+bCWJlEWlwcxFTVY3WT86dFpKwbZaGWZV6C5Rd7sCk1Z0CI76QEfukLAUXw==}
@@ -4860,6 +4889,12 @@ snapshots:
   '@chevrotain/types@10.5.0': {}
 
   '@chevrotain/utils@10.5.0': {}
+
+  '@clickhouse/client-common@1.16.0': {}
+
+  '@clickhouse/client@1.16.0':
+    dependencies:
+      '@clickhouse/client-common': 1.16.0
 
   '@electric-sql/pglite-socket@0.0.6(@electric-sql/pglite@0.3.2)':
     dependencies:


### PR DESCRIPTION
Fixes #9 
- add `@repo/clickhouse` workspace package with typed client and bulk insert
- create `uptime_checks` MergeTree table with proper schema (Enum status, DateTime64)
- refactor worker to batch website checks with Promise.allSettled and atomic acks
- add axios timeout (10s), maxRedirects (5), and proper UP/DOWN status tracking
- expose ClickHouse config vars and ensure schema on first insert