### PR TITLE
chore(github-actions): switch deploy workflow trigger to push on main

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -1,17 +1,12 @@
 name: Deploy
 
 on:
-  workflow_run:
-    workflows: ["Tests"]
-    types:
-      - completed
-
+  push:
+    branches: [main]
   workflow_dispatch:
 
 jobs:
   deploy:
-    # Only deploy if Tests workflow succeeded
-    if: ${{ github.event.workflow_run.conclusion == 'success' }}
     runs-on: ubuntu-latest
 
     steps:


### PR DESCRIPTION
- Remove `workflow_run` trigger on Tests completion
- Add `push` trigger for `main` branch
- Retain `workflow_dispatch` for manual runs
- Remove conditional `if` check relying on `github.event.workflow_run.conclusion`