### PR TITLE
fix(github-actions): add fallback pnpm installation via npm if corepack not available

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -36,9 +36,22 @@ jobs:
             git checkout main
             git pull origin main
 
-            echo "Ensuring pnpm version..."
-            corepack enable
-            corepack prepare pnpm@9 --activate
+            echo "Ensuring pnpm is available..."
+            if command -v corepack >/dev/null 2>&1; then
+              echo "Using corepack to enable pnpm..."
+              corepack enable
+              corepack prepare pnpm@9 --activate
+            else
+              echo "corepack not found; ensuring pnpm via npm..."
+              if ! command -v pnpm >/dev/null 2>&1; then
+                if command -v npm >/dev/null 2>&1; then
+                  npm install -g pnpm@9
+                else
+                  echo "Neither corepack nor npm is available; cannot install pnpm."
+                  exit 1
+                fi
+              fi
+            fi
 
             echo "Installing dependencies..."
             pnpm install --frozen-lockfile


### PR DESCRIPTION
Fixex #24 

- Check for corepack availability before enabling/preparing pnpm@9
- Install pnpm@9 globally via npm if corepack missing and pnpm not present
- Fail workflow if neither corepack nor npm available
- Preserve existing pnpm install --frozen-lockfile step