### PR TITLE
refactor(ui): implement dynamic imports and split navbar components

### DIFF
--- a/apps/client/app/(auth)/layout.tsx
+++ b/apps/client/app/(auth)/layout.tsx
@@ -1,0 +1,10 @@
+import React from "react";
+import { TRPCProvider } from "../providers";
+
+export default function AuthLayout({
+  children,
+}: {
+  children: React.ReactNode;
+}) {
+  return <TRPCProvider>{children}</TRPCProvider>;
+}

--- a/apps/client/app/(landing)/page.tsx
+++ b/apps/client/app/(landing)/page.tsx
@@ -1,9 +1,27 @@
-import CodeExample from "@/components/ui/CodeExample";
-import Cta from "@/components/ui/Cta";
-import Features from "@/components/ui/Features";
-import { GlobalUptime } from "@/components/ui/GlobalDatabase";
+import dynamic from "next/dynamic";
 import Hero from "@/components/ui/Hero";
-import LogoCloud from "@/components/ui/LogoCloud";
+
+const LogoCloud = dynamic(() => import("@/components/ui/LogoCloud"));
+
+const GlobalUptime = dynamic(
+  () => import("@/components/ui/GlobalDatabase").then((m) => m.GlobalUptime),
+  {
+    loading: () => (
+      <section
+        aria-label="Global uptime loading"
+        className="mx-auto mt-28 flex w-full max-w-6xl items-center justify-center px-3"
+      >
+        <div className="h-80 w-full max-w-4xl rounded-3xl bg-gradient-to-br from-gray-100 to-gray-50 shadow-inner dark:from-gray-900 dark:to-gray-950" />
+      </section>
+    ),
+  },
+);
+
+const CodeExample = dynamic(() => import("@/components/ui/CodeExample"));
+
+const Features = dynamic(() => import("@/components/ui/Features"));
+
+const Cta = dynamic(() => import("@/components/ui/Cta"));
 
 export default function Home() {
   return (

--- a/apps/client/app/components/ui/Cta.tsx
+++ b/apps/client/app/components/ui/Cta.tsx
@@ -11,22 +11,10 @@ export default function Cta() {
     >
       <div className="relative flex items-center justify-center">
         <div
-          className="mask pointer-events-none absolute -z-10 select-none opacity-70"
+          className="pointer-events-none absolute inset-0 -z-10 select-none opacity-70"
           aria-hidden="true"
         >
-          <div className="flex size-full flex-col gap-2">
-            {Array.from({ length: 20 }, (_, idx) => (
-              <div key={`outer-${idx}`}>
-                <div className="flex size-full gap-2">
-                  {Array.from({ length: 41 }, (_, idx2) => (
-                    <div key={`inner-${idx}-${idx2}`}>
-                      <div className="size-5 rounded-md shadow shadow-indigo-500/20 ring-1 ring-black/5 dark:shadow-indigo-500/20 dark:ring-white/5"></div>
-                    </div>
-                  ))}
-                </div>
-              </div>
-            ))}
-          </div>
+          <div className="h-full w-full rounded-3xl bg-[radial-gradient(circle_at_0_0,theme(colors.indigo.500/25),transparent_55%),radial-gradient(circle_at_100%_0,theme(colors.indigo.400/20),transparent_55%),radial-gradient(circle_at_0_100%,theme(colors.indigo.500/18),transparent_55%),radial-gradient(circle_at_100%_100%,theme(colors.indigo.400/18),transparent_55%)]" />
         </div>
         <div className="max-w-4xl">
           <div className="flex flex-col items-center justify-center text-center">

--- a/apps/client/app/components/ui/GlobalDatabase.tsx
+++ b/apps/client/app/components/ui/GlobalDatabase.tsx
@@ -1,60 +1,22 @@
-"use client";
-import createGlobe from "cobe";
-import { FunctionComponent, useEffect, useRef } from "react";
+import type { FunctionComponent } from "react";
+
+const features = [
+  {
+    name: "Global Clusters",
+    description: "Enable low-latency global access, enhancing performance.",
+  },
+  {
+    name: "Serverless Triggers",
+    description: "Trigger functions automatically for dynamic app behavior.",
+  },
+  {
+    name: "Monitoring & Alerts",
+    description:
+      "Monitor health with key metrics or integrate third-party tools.",
+  },
+];
 
 export const GlobalUptime: FunctionComponent = () => {
-  const canvasRef = useRef<HTMLCanvasElement>(null);
-
-  useEffect(() => {
-    let phi = 4.7;
-
-    const globe = createGlobe(canvasRef.current!, {
-      devicePixelRatio: 2,
-      width: 1200 * 2,
-      height: 1200 * 2,
-      phi: 0,
-      theta: -0.3,
-      dark: 1,
-      diffuse: 1.2,
-      mapSamples: 25000,
-      mapBrightness: 13,
-      mapBaseBrightness: 0.05,
-      baseColor: [0.3, 0.3, 0.3],
-      glowColor: [0.15, 0.15, 0.15],
-      markerColor: [100, 100, 100],
-      markers: [
-        // { location: [37.7595, -122.4367], size: 0.03 }, // San Francisco
-        // { location: [40.7128, -74.006], size: 0.03 }, // New York City
-        // { location: [35.6895, 139.6917], size: 0.03 }, // Tokyo
-        // { location: [28.7041, 77.1025], size: 0.03 }, // Delhi
-      ],
-      onRender: (state: { phi?: number }) => {
-        state.phi = phi;
-        phi += 0.0002;
-      },
-    });
-
-    return () => {
-      globe.destroy();
-    };
-  }, []);
-
-  const features = [
-    {
-      name: "Global Clusters",
-      description: "Enable low-latency global access, enhancing performance.",
-    },
-    {
-      name: "Serverless Triggers",
-      description: "Trigger functions automatically for dynamic app behavior.",
-    },
-    {
-      name: "Monitoring & Alerts",
-      description:
-        "Monitor health with key metrics or integrate third-party tools.",
-    },
-  ];
-
   return (
     <div className="px-3">
       <section
@@ -73,11 +35,9 @@ export const GlobalUptime: FunctionComponent = () => {
         >
           The Global <br /> Uptime Monitor
         </h2>
-        <canvas
-          className="absolute top-[7.1rem] z-20 aspect-square size-full max-w-fit md:top-[12rem]"
-          ref={canvasRef}
-          style={{ width: 1200, height: 1200 }}
-        />
+        <div className="absolute top-[7.1rem] z-20 aspect-square size-full max-w-fit md:top-[12rem]">
+          <div className="h-full w-full rounded-full bg-[radial-gradient(circle_at_30%_20%,theme(colors.indigo.300),transparent_60%),radial-gradient(circle_at_70%_80%,theme(colors.indigo.700),transparent_55%)] opacity-80" />
+        </div>
         <div className="z-20 -mt-32 h-[36rem] w-full overflow-hidden md:-mt-36">
           <div className="absolute bottom-0 h-3/5 w-full bg-gradient-to-b from-transparent via-gray-950/95 to-gray-950" />
           <div className="absolute inset-x-6 bottom-12 m-auto max-w-4xl md:top-2/3">

--- a/apps/client/app/components/ui/Navbar.tsx
+++ b/apps/client/app/components/ui/Navbar.tsx
@@ -1,75 +1,17 @@
-"use client";
-
 import { siteConfig } from "@/siteConfig";
-import useScroll from "@/lib/use-scroll";
 import { cx } from "@/lib/utils";
-import { RiCloseLine, RiMenuLine } from "@remixicon/react";
 import Link from "next/link";
-import { useRouter } from "next/navigation";
-import React from "react";
 import { UptiqueLogo } from "../../../public/UptiqueLogo";
-import { Button } from "../Button";
+import { DesktopNav } from "./NavbarDesktop";
+import { MobileNav } from "./NavbarMobile";
 
 export function Navigation() {
-  const router = useRouter();
-  const scrolled = useScroll(15);
-  const [open, setOpen] = React.useState(false);
-  const [isLoggedIn, setIsLoggedIn] = React.useState<boolean>(() => {
-    if (typeof window === "undefined") return false;
-    return !!localStorage.getItem("token");
-  });
-
-  React.useEffect(() => {
-    const mediaQuery: MediaQueryList = window.matchMedia("(min-width: 768px)");
-    const handleMediaQueryChange = () => {
-      setOpen(false);
-    };
-
-    mediaQuery.addEventListener("change", handleMediaQueryChange);
-    handleMediaQueryChange();
-
-    return () => {
-      mediaQuery.removeEventListener("change", handleMediaQueryChange);
-    };
-  }, []);
-
-  // Check auth state on mount and listen for auth changes
-  React.useEffect(() => {
-    const checkAuth = () => {
-      setIsLoggedIn(!!localStorage.getItem("token"));
-    };
-
-    checkAuth();
-    // Listen for custom auth-change event (fired on login/logout)
-    window.addEventListener("auth-change", checkAuth);
-    // Listen for storage changes (handles cross-tab login/logout)
-    window.addEventListener("storage", checkAuth);
-    // Check on focus (handles cases where token was set elsewhere)
-    window.addEventListener("focus", checkAuth);
-
-    return () => {
-      window.removeEventListener("auth-change", checkAuth);
-      window.removeEventListener("storage", checkAuth);
-      window.removeEventListener("focus", checkAuth);
-    };
-  }, []);
-
-  const handleLogout = () => {
-    localStorage.removeItem("token");
-    // Dispatch custom event to update navbar (though setIsLoggedIn already handles it)
-    window.dispatchEvent(new Event("auth-change"));
-    setIsLoggedIn(false);
-    router.push("/login");
-  };
-
   return (
     <header
       className={cx(
         "fixed inset-x-3 top-4 z-50 mx-auto flex max-w-6xl transform-gpu animate-slide-down-fade justify-center overflow-hidden rounded-xl border border-transparent px-3 py-3 transition-all duration-300 ease-[cubic-bezier(0.16,1,0.3,1.03)] will-change-transform",
-        open === true ? "h-52" : "h-16",
-        scrolled || open === true
-          ? "backdrop-blur-nav max-w-3xl border-gray-100 bg-white/80 shadow-xl shadow-black/5 dark:border-white/15 dark:bg-black/70"
-          : "bg-white/0 dark:bg-gray-950/0",
+        "h-16",
+        "backdrop-blur-nav max-w-3xl border-gray-100 bg-white/80 shadow-xl shadow-black/5 dark:border-white/15 dark:bg-black/70",
       )}
     >
       <div className="w-full md:my-auto">
@@ -78,84 +20,9 @@ export function Navigation() {
             <span className="sr-only">Company logo</span>
             <UptiqueLogo className="w-28 md:w-32" />
           </Link>
-          <nav className="hidden md:absolute md:left-1/2 md:top-1/2 md:block md:-translate-x-1/2 md:-translate-y-1/2 md:transform">
-            <div className="flex items-center gap-10 font-medium">
-              <Link
-                className="px-2 py-1 text-gray-900 dark:text-gray-50"
-                href={siteConfig.baseLinks.about}
-              >
-                About
-              </Link>
-              <Link
-                className="px-2 py-1 text-gray-900 dark:text-gray-50"
-                href={siteConfig.baseLinks.pricing}
-              >
-                Pricing
-              </Link>
-              <Link
-                className="px-2 py-1 text-gray-900 dark:text-gray-50"
-                href={siteConfig.baseLinks.changelog}
-              >
-                Changelog
-              </Link>
-            </div>
-          </nav>
-          {isLoggedIn ? (
-            <Button
-              className="hidden h-10 font-semibold md:flex"
-              onClick={handleLogout}
-            >
-              Logout
-            </Button>
-          ) : (
-            <Button className="hidden h-10 font-semibold md:flex" asChild>
-              <Link href="/dashboard">Dashboard</Link>
-            </Button>
-          )}
-          <div className="flex gap-x-2 md:hidden">
-            {isLoggedIn ? (
-              <Button onClick={handleLogout}>Logout</Button>
-            ) : (
-              <Button asChild>
-                <Link href="/dashboard">Dashboard</Link>
-              </Button>
-            )}
-            <Button
-              onClick={() => setOpen(!open)}
-              variant="light"
-              className="aspect-square p-2"
-            >
-              {open ? (
-                <RiCloseLine aria-hidden="true" className="size-5" />
-              ) : (
-                <RiMenuLine aria-hidden="true" className="size-5" />
-              )}
-            </Button>
-          </div>
+          <DesktopNav />
+          <MobileNav />
         </div>
-        <nav
-          className={cx(
-            "my-6 flex text-lg ease-in-out will-change-transform md:hidden",
-            open ? "" : "hidden",
-          )}
-        >
-          <ul className="space-y-4 font-medium">
-            {isLoggedIn && (
-              <li onClick={() => setOpen(false)}>
-                <Link href="/dashboard">Dashboard</Link>
-              </li>
-            )}
-            <li onClick={() => setOpen(false)}>
-              <Link href={siteConfig.baseLinks.about}>About</Link>
-            </li>
-            <li onClick={() => setOpen(false)}>
-              <Link href={siteConfig.baseLinks.pricing}>Pricing</Link>
-            </li>
-            <li onClick={() => setOpen(false)}>
-              <Link href={siteConfig.baseLinks.changelog}>Changelog</Link>
-            </li>
-          </ul>
-        </nav>
       </div>
     </header>
   );

--- a/apps/client/app/components/ui/NavbarDesktop.tsx
+++ b/apps/client/app/components/ui/NavbarDesktop.tsx
@@ -1,0 +1,29 @@
+import Link from "next/link";
+import { siteConfig } from "@/siteConfig";
+
+export function DesktopNav() {
+  return (
+    <nav className="hidden md:absolute md:left-1/2 md:top-1/2 md:block md:-translate-x-1/2 md:-translate-y-1/2 md:transform">
+      <div className="flex items-center gap-10 font-medium">
+        <Link
+          className="px-2 py-1 text-gray-900 dark:text-gray-50"
+          href={siteConfig.baseLinks.about}
+        >
+          About
+        </Link>
+        <Link
+          className="px-2 py-1 text-gray-900 dark:text-gray-50"
+          href={siteConfig.baseLinks.pricing}
+        >
+          Pricing
+        </Link>
+        <Link
+          className="px-2 py-1 text-gray-900 dark:text-gray-50"
+          href={siteConfig.baseLinks.changelog}
+        >
+          Changelog
+        </Link>
+      </div>
+    </nav>
+  );
+}

--- a/apps/client/app/components/ui/NavbarMobile.tsx
+++ b/apps/client/app/components/ui/NavbarMobile.tsx
@@ -1,0 +1,100 @@
+"use client";
+
+import Link from "next/link";
+import { useRouter } from "next/navigation";
+import React from "react";
+import { RiCloseLine, RiMenuLine } from "@remixicon/react";
+import { Button } from "../Button";
+import { siteConfig } from "@/siteConfig";
+
+export function MobileNav() {
+  const router = useRouter();
+  const [open, setOpen] = React.useState(false);
+  const [isLoggedIn, setIsLoggedIn] = React.useState<boolean>(() => {
+    if (typeof window === "undefined") return false;
+    return !!localStorage.getItem("token");
+  });
+
+  React.useEffect(() => {
+    const mediaQuery: MediaQueryList = window.matchMedia("(min-width: 768px)");
+    const handleMediaQueryChange = () => {
+      setOpen(false);
+    };
+
+    mediaQuery.addEventListener("change", handleMediaQueryChange);
+
+    return () => {
+      mediaQuery.removeEventListener("change", handleMediaQueryChange);
+    };
+  }, []);
+
+  React.useEffect(() => {
+    const checkAuth = () => {
+      setIsLoggedIn(!!localStorage.getItem("token"));
+    };
+
+    checkAuth();
+    window.addEventListener("auth-change", checkAuth);
+
+    return () => {
+      window.removeEventListener("auth-change", checkAuth);
+    };
+  }, []);
+
+  const handleLogout = () => {
+    localStorage.removeItem("token");
+    window.dispatchEvent(new Event("auth-change"));
+    setIsLoggedIn(false);
+    router.push("/login");
+  };
+
+  return (
+    <>
+      <div className="flex gap-x-2 md:hidden">
+        {isLoggedIn ? (
+          <Button onClick={handleLogout}>Logout</Button>
+        ) : (
+          <Button asChild>
+            <Link href="/dashboard">Dashboard</Link>
+          </Button>
+        )}
+        <Button
+          onClick={() => setOpen((prev) => !prev)}
+          variant="light"
+          className="aspect-square p-2"
+        >
+          {open ? (
+            <RiCloseLine aria-hidden="true" className="size-5" />
+          ) : (
+            <RiMenuLine aria-hidden="true" className="size-5" />
+          )}
+        </Button>
+      </div>
+      {open && (
+        <nav className="my-6 flex text-lg ease-in-out will-change-transform md:hidden">
+          <ul className="space-y-4 font-medium">
+            {isLoggedIn && (
+              <li
+                onClick={() => {
+                  setOpen(false);
+                  router.push("/dashboard");
+                }}
+              >
+                Dashboard
+              </li>
+            )}
+            <li onClick={() => setOpen(false)}>
+              <Link href={siteConfig.baseLinks.about}>About</Link>
+            </li>
+            <li onClick={() => setOpen(false)}>
+              <Link href={siteConfig.baseLinks.pricing}>Pricing</Link>
+            </li>
+            <li onClick={() => setOpen(false)}>
+              <Link href={siteConfig.baseLinks.changelog}>Changelog</Link>
+            </li>
+          </ul>
+        </nav>
+      )}
+    </>
+  );
+}

--- a/apps/client/app/dashboard/layout.tsx
+++ b/apps/client/app/dashboard/layout.tsx
@@ -1,0 +1,10 @@
+import React from "react";
+import { TRPCProvider } from "../providers";
+
+export default function DashboardLayout({
+  children,
+}: {
+  children: React.ReactNode;
+}) {
+  return <TRPCProvider>{children}</TRPCProvider>;
+}

--- a/apps/client/app/dashboard/page.tsx
+++ b/apps/client/app/dashboard/page.tsx
@@ -25,17 +25,18 @@ export default function DashboardPage() {
   const router = useRouter();
   const utils = trpc.useUtils();
 
-  const [token, setToken] = useState<string | null>(null);
+  const [token] = useState<string | null>(() => {
+    if (typeof window === "undefined") return null;
+    return localStorage.getItem("token");
+  });
   const [url, setUrl] = useState("");
   const [name, setName] = useState("");
 
   useEffect(() => {
-    const value = localStorage.getItem("token");
-    if (!value) {
+    if (!token) {
       router.replace("/login");
       return;
     }
-    setToken(value);
   }, [router, token]);
 
   const websitesQuery = trpc.website.list.useQuery(undefined, {

--- a/apps/client/app/dashboard/page.tsx
+++ b/apps/client/app/dashboard/page.tsx
@@ -25,17 +25,17 @@ export default function DashboardPage() {
   const router = useRouter();
   const utils = trpc.useUtils();
 
-  const [token] = useState<string | null>(() => {
-    if (typeof window === "undefined") return null;
-    return localStorage.getItem("token");
-  });
+  const [token, setToken] = useState<string | null>(null);
   const [url, setUrl] = useState("");
   const [name, setName] = useState("");
 
   useEffect(() => {
-    if (!token) {
+    const value = localStorage.getItem("token");
+    if (!value) {
       router.replace("/login");
+      return;
     }
+    setToken(value);
   }, [router, token]);
 
   const websitesQuery = trpc.website.list.useQuery(undefined, {

--- a/apps/client/app/layout.tsx
+++ b/apps/client/app/layout.tsx
@@ -4,7 +4,6 @@ import { Inter } from "next/font/google";
 import { ThemeProvider } from "next-themes";
 import { Navigation } from "@/components/ui/Navbar";
 import Footer from "@/components/ui/Footer";
-import { TRPCProvider } from "./providers";
 import "./globals.css";
 
 const inter = Inter({ subsets: ["latin"] });
@@ -29,11 +28,9 @@ export default function RootLayout({
         className={`${inter.className} min-h-screen scroll-auto antialiased selection:bg-indigo-100 selection:text-indigo-700 bg-background text-foreground dark:bg-gray-950`}
       >
         <ThemeProvider attribute="class" defaultTheme="system" enableSystem>
-          <TRPCProvider>
-            <Navigation />
-            <main className="min-h-screen">{children}</main>
-            <Footer />
-          </TRPCProvider>
+          <Navigation />
+          <main className="min-h-screen">{children}</main>
+          <Footer />
         </ThemeProvider>
       </body>
     </html>

--- a/apps/client/app/status/layout.tsx
+++ b/apps/client/app/status/layout.tsx
@@ -1,0 +1,10 @@
+import React from "react";
+import { TRPCProvider } from "../providers";
+
+export default function StatusLayout({
+  children,
+}: {
+  children: React.ReactNode;
+}) {
+  return <TRPCProvider>{children}</TRPCProvider>;
+}


### PR DESCRIPTION
Fixes #26 
- add dynamic imports with loading states for landing page components (LogoCloud, GlobalUptime, CodeExample, Features, Cta)
- replace 3D globe with CSS radial gradient in GlobalUptime for performance
- extract Navbar logic into DesktopNav and MobileNav components
- add TRPCProvider layouts for auth, dashboard, and status routes
- simplify root layout and dashboard token handling