### PR TITLE
config: update backend URL to production endpoint

### DIFF
--- a/packages/config/src/constants.ts
+++ b/packages/config/src/constants.ts
@@ -2,7 +2,7 @@
 // No Bun-specific APIs here
 
 export const BACKEND_PORT = 8084;
-export const BACKEND_URL = `http://localhost:${BACKEND_PORT}`;
+export const BACKEND_URL = "https://www.uptique-server.raashed.xyz";
 export const FRONTEND_URL = "http://localhost:3000";
 
 // GitHub OAuth URLs


### PR DESCRIPTION
Fixes #27 
- Replace `http://localhost:${BACKEND_PORT}` with `https://www.uptique-server.raashed.xyz` in constants.ts
- Retain BACKEND_PORT at 8084 and FRONTEND_URL unchanged