### PR TITLE
refactor(cors): externalize CORS allowed origins to configuration

### DIFF
--- a/apps/server/src/bin.ts
+++ b/apps/server/src/bin.ts
@@ -2,11 +2,12 @@ import { createHTTPServer } from "@trpc/server/adapters/standalone";
 import cors from "cors";
 import { createContext } from "@repo/api/trpc";
 import { BACKEND_PORT } from "@repo/config";
+import { CORS_ALLOWED_ORIGINS } from "@repo/config/constants";
 import { appRouter } from "./index";
 
 const server = createHTTPServer({
   middleware: cors({
-    origin: ["http://localhost:3000", "https://yourdomain.com"],
+    origin: CORS_ALLOWED_ORIGINS,
     credentials: true,
   }),
   router: appRouter,

--- a/packages/config/src/constants.ts
+++ b/packages/config/src/constants.ts
@@ -8,7 +8,19 @@ export const BACKEND_URL =
   process.env.NODE_ENV === "production"
     ? BACKEND_URL_PRODUCTION
     : BACKEND_URL_DEVELOPMENT;
-export const FRONTEND_URL = "http://localhost:3000";
+
+export const FRONTEND_URL_PRODUCTION = "https://uptique.raashed.xyz";
+export const FRONTEND_URL_DEVELOPMENT = "http://localhost:3000";
+export const FRONTEND_URL =
+  process.env.NODE_ENV === "production"
+    ? FRONTEND_URL_PRODUCTION
+    : FRONTEND_URL_DEVELOPMENT;
+
+// CORS allowed origins for the backend
+export const CORS_ALLOWED_ORIGINS = [
+  FRONTEND_URL_DEVELOPMENT,
+  FRONTEND_URL_PRODUCTION,
+];
 
 // GitHub OAuth URLs
 export const GITHUB_OAUTH_URL = "https://github.com/login/oauth/authorize";


### PR DESCRIPTION
Fixes #34 

- Extract hardcoded origin array from server middleware into centralized config
- Define separate development and production frontend URLs with environment-based selection
- Improve maintainability by centralizing CORS origin management in constants file
- Enable consistent origin configuration across the application stack