### PR TITLE
fix(worker): set DOWN status for HTTP 4xx responses in website check

### DIFF
--- a/apps/worker/src/index.ts
+++ b/apps/worker/src/index.ts
@@ -27,13 +27,17 @@ async function checkWebsite(
   const checkedAt = new Date();
 
   try {
-    await axios.get(url, {
+    const res = await axios.get(url, {
       timeout: 10_000,
       maxRedirects: 5,
       validateStatus: () => true,
     });
 
     responseTimeMs = Date.now() - startTime;
+
+    if (res.status >= 400) {
+      status = "DOWN";
+    }
   } catch {
     status = "DOWN";
   }


### PR DESCRIPTION
- Capture axios response explicitly to access status code
- Check `res.status >= 400` after successful request to set `status = "DOWN"`
- Preserve existing catch block for network or other errors