### PR TITLE
chore(deploy): add Prisma client generation step

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -73,6 +73,9 @@ jobs:
             echo "Installing dependencies..."
             pnpm install --frozen-lockfile
 
+            echo "Generating Prisma Client..."
+            pnpm --filter @repo/store prisma:generate
+
             echo "Building application..."
             pnpm build
 


### PR DESCRIPTION
- Add `pnpm --filter @repo/store prisma:generate` before build in deploy workflow
- Ensures generated client is available for monorepo store package during deployment[1][5]