### PR TITLE
feat(clickhouse): add region_id field to status events response type

### DIFF
--- a/packages/clickhouse/src/index.ts
+++ b/packages/clickhouse/src/index.ts
@@ -225,6 +225,7 @@ export async function getRecentStatusEvents(
 
   const data = (await result.json()) as Array<{
     website_id: string;
+    region_id: string;
     status: "UP" | "DOWN";
     checked_at: string;
     response_time_ms: number | null;


### PR DESCRIPTION
- Extend getRecentStatusEvents result type to include region_id property
- Align response type definition with ClickHouse query output schema
- Enable region-based filtering and analysis of status event data