### PR TITLE
feat: add diagonal stripe borders to no-navbar layout

### DIFF
--- a/apps/client/app/(no-navbar)/layout.tsx
+++ b/apps/client/app/(no-navbar)/layout.tsx
@@ -7,6 +7,16 @@ export default function NoNavbarLayout({
 }) {
   return (
     <>
+      {/* Left diagonal stripe border */}
+      <div
+        className="diagonal-stripes pointer-events-none fixed top-0 left-0 z-10 hidden h-full w-24 lg:block"
+        aria-hidden="true"
+      />
+      {/* Right diagonal stripe border */}
+      <div
+        className="diagonal-stripes pointer-events-none fixed top-0 right-0 z-10 hidden h-full w-24 lg:block"
+        aria-hidden="true"
+      />
       <main className="min-h-screen">{children}</main>
       <Footer />
     </>

--- a/apps/client/app/globals.css
+++ b/apps/client/app/globals.css
@@ -121,3 +121,20 @@
     @apply bg-background text-foreground;
   }
 }
+
+/* Diagonal striped border pattern */
+.diagonal-stripes {
+  --stripe-color: oklch(0.3 0 0 / 40%);
+  --stripe-bg: transparent;
+  background: repeating-linear-gradient(
+    -45deg,
+    var(--stripe-bg),
+    var(--stripe-bg) 8px,
+    var(--stripe-color) 8px,
+    var(--stripe-color) 9px
+  );
+}
+
+.dark .diagonal-stripes {
+  --stripe-color: oklch(0.4 0 0 / 50%);
+}


### PR DESCRIPTION
- Implement fixed positioned diagonal stripe elements on left and right edges
- Apply repeating linear gradient pattern with -45deg angle for striped effect
- Configure responsive visibility with lg breakpoint and pointer-events-none for non-interactive overlay
- Define CSS custom properties for stripe color with dark mode support using oklch color space