### PR TITLE
feat(client): reposition diagonal stripe borders to center with content

### DIFF
--- a/apps/client/app/(no-navbar)/layout.tsx
+++ b/apps/client/app/(no-navbar)/layout.tsx
@@ -7,17 +7,21 @@ export default function NoNavbarLayout({
 }) {
   return (
     <>
-      {/* Left diagonal stripe border */}
-      <div
-        className="diagonal-stripes pointer-events-none fixed top-0 left-0 z-10 hidden h-full w-24 lg:block"
-        aria-hidden="true"
-      />
-      {/* Right diagonal stripe border */}
-      <div
-        className="diagonal-stripes pointer-events-none fixed top-0 right-0 z-10 hidden h-full w-24 lg:block"
-        aria-hidden="true"
-      />
-      <main className="min-h-screen">{children}</main>
+      <main className="relative min-h-screen">
+        {/* Stripe borders container - centered with content */}
+        <div
+          className="pointer-events-none absolute inset-0 hidden justify-center lg:flex"
+          aria-hidden="true"
+        >
+          <div className="flex w-full max-w-5xl">
+            {/* Left diagonal stripe border */}
+            <div className="diagonal-stripes absolute -left-4 h-full w-3 -translate-x-full" />
+            {/* Right diagonal stripe border */}
+            <div className="diagonal-stripes absolute -right-4 h-full w-3 translate-x-full" />
+          </div>
+        </div>
+        {children}
+      </main>
       <Footer />
     </>
   );

--- a/apps/client/app/globals.css
+++ b/apps/client/app/globals.css
@@ -124,17 +124,17 @@
 
 /* Diagonal striped border pattern */
 .diagonal-stripes {
-  --stripe-color: oklch(0.3 0 0 / 40%);
+  --stripe-color: oklch(0.3 0 0 / 30%);
   --stripe-bg: transparent;
   background: repeating-linear-gradient(
     -45deg,
     var(--stripe-bg),
-    var(--stripe-bg) 8px,
-    var(--stripe-color) 8px,
-    var(--stripe-color) 9px
+    var(--stripe-bg) 6px,
+    var(--stripe-color) 6px,
+    var(--stripe-color) 7px
   );
 }
 
 .dark .diagonal-stripes {
-  --stripe-color: oklch(0.4 0 0 / 50%);
+  --stripe-color: oklch(0.45 0 0 / 40%);
 }


### PR DESCRIPTION
- Restructure stripe borders into centered container with `max-w-5xl` using absolute positioning and transforms
- Reduce stripe width from `w-24` to `w-3` and adjust offsets (`-left-4`/`-right-4`)
- Update `.diagonal-stripes` CSS: stripe opacity from 40%/50% to 30%/40%, size from 8-9px to 6-7px
- Add `Footer` component to layout