### PR TITLE
feat(auth): add GitHub OAuth redirect URI configuration

### DIFF
--- a/apps/client/app/(main)/(auth)/login/page.tsx
+++ b/apps/client/app/(main)/(auth)/login/page.tsx
@@ -5,7 +5,7 @@ import Link from "next/link";
 import { useRouter, useSearchParams } from "next/navigation";
 import { toast } from "sonner";
 import { trpc } from "@/lib/trpc";
-import { GITHUB_OAUTH_URL } from "@repo/config/constants";
+import { GITHUB_OAUTH_URL, FRONTEND_URL } from "@repo/config/constants";
 import { Button } from "@/components/Button";
 
 function getErrorMessage(error: { message: string }): string {
@@ -27,6 +27,7 @@ function handleGitHubLogin() {
 
   const params = new URLSearchParams({
     client_id: process.env.NEXT_PUBLIC_GITHUB_CLIENT_ID || "",
+    redirect_uri: `${FRONTEND_URL}/api/auth/github/callback`,
     scope: "read:user user:email",
     state,
   });

--- a/apps/client/app/(main)/(auth)/signup/page.tsx
+++ b/apps/client/app/(main)/(auth)/signup/page.tsx
@@ -4,7 +4,7 @@ import { useState, useEffect, useRef } from "react";
 import Link from "next/link";
 import { toast } from "sonner";
 import { trpc } from "@/lib/trpc";
-import { GITHUB_OAUTH_URL } from "@repo/config/constants";
+import { GITHUB_OAUTH_URL, FRONTEND_URL } from "@repo/config/constants";
 import { Button } from "@/components/Button";
 
 function getErrorMessage(error: { message: string }): string {
@@ -26,6 +26,7 @@ function handleGitHubLogin() {
 
   const params = new URLSearchParams({
     client_id: process.env.NEXT_PUBLIC_GITHUB_CLIENT_ID || "",
+    redirect_uri: `${FRONTEND_URL}/api/auth/github/callback`,
     scope: "read:user user:email",
     state,
   });

--- a/apps/client/app/api/auth/github/callback/route.ts
+++ b/apps/client/app/api/auth/github/callback/route.ts
@@ -2,13 +2,12 @@ import { NextRequest, NextResponse } from "next/server";
 import jwt from "jsonwebtoken";
 import { PrismaClient } from "@repo/store/generated/prisma";
 import { PrismaNeon } from "@prisma/adapter-neon";
-
-// GitHub OAuth URLs
-const GITHUB_TOKEN_URL = "https://github.com/login/oauth/access_token";
-const GITHUB_USER_URL = "https://api.github.com/user";
-const GITHUB_EMAILS_URL = "https://api.github.com/user/emails";
-const FRONTEND_URL =
-  process.env.NEXT_PUBLIC_FRONTEND_URL || "http://localhost:3000";
+import {
+  GITHUB_TOKEN_URL,
+  GITHUB_USER_URL,
+  GITHUB_EMAILS_URL,
+  FRONTEND_URL,
+} from "@repo/config/constants";
 
 // Create Prisma client for Next.js (doesn't use Bun-dependent config)
 const adapter = new PrismaNeon({ connectionString: process.env.DATABASE_URL! });


### PR DESCRIPTION
Fixes #40 
- Import `FRONTEND_URL` from constants in login and signup pages
- Set `redirect_uri` to `${FRONTEND_URL}/api/auth/github/callback` in GitHub OAuth params
- Import OAuth constants (`GITHUB_TOKEN_URL`, `GITHUB_USER_URL`, `GITHUB_EMAILS_URL`, `FRONTEND_URL`) in callback route
- Remove hardcoded `FRONTEND_URL` and GitHub URLs from callback route