### PR TITLE
fix(ui): set default theme to light in ThemeProvider

### DIFF
--- a/apps/client/app/layout.tsx
+++ b/apps/client/app/layout.tsx
@@ -26,7 +26,7 @@ export default function RootLayout({
       <body
         className={`${inter.className} min-h-screen scroll-auto antialiased selection:bg-indigo-100 selection:text-indigo-700 bg-background text-foreground dark:bg-gray-950`}
       >
-        <ThemeProvider attribute="class" defaultTheme="system" enableSystem>
+        <ThemeProvider attribute="class" defaultTheme="light" enableSystem>
           <TRPCProvider>{children}</TRPCProvider>
         </ThemeProvider>
       </body>


### PR DESCRIPTION
Fixes #28 
- Change `defaultTheme` from `"system"` to `"light"` in `RootLayout`