### PR TITLE
feat(ui): enhance text color consistency across dashboard and status …

### DIFF
--- a/apps/client/app/(main)/dashboard/page.tsx
+++ b/apps/client/app/(main)/dashboard/page.tsx
@@ -177,7 +177,7 @@ export default function DashboardPage() {
       {/* Header with Profile Dropdown */}
       <div className="flex items-center justify-between mb-8">
         <div className="space-y-1">
-          <h1 className="text-2xl font-semibold tracking-tight">
+          <h1 className="text-2xl font-semibold tracking-tight text-foreground">
             {dashboardTitle}
           </h1>
           <p className="text-sm text-muted-foreground">

--- a/apps/client/app/(no-navbar)/status/page.tsx
+++ b/apps/client/app/(no-navbar)/status/page.tsx
@@ -259,7 +259,7 @@ export default function StatusPage() {
 
       <div className="flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">
         <div className="space-y-1">
-          <h1 className="text-2xl font-semibold tracking-tight">
+          <h1 className="text-2xl font-semibold tracking-tight text-foreground">
             Website Status
           </h1>
           <p className="text-sm text-muted-foreground">

--- a/apps/client/app/components/ui/breadcrumb.tsx
+++ b/apps/client/app/components/ui/breadcrumb.tsx
@@ -43,7 +43,10 @@ function BreadcrumbLink({
   return (
     <Comp
       data-slot="breadcrumb-link"
-      className={cx("hover:text-foreground transition-colors", className)}
+      className={cx(
+        "text-foreground/70 hover:text-foreground transition-colors",
+        className,
+      )}
       {...props}
     />
   );
@@ -72,7 +75,7 @@ function BreadcrumbSeparator({
       data-slot="breadcrumb-separator"
       role="presentation"
       aria-hidden="true"
-      className={cx("[&>svg]:size-3.5", className)}
+      className={cx("[&>svg]:size-3.5 text-foreground/50", className)}
       {...props}
     >
       {children ?? <ChevronRight />}


### PR DESCRIPTION
…pages

- Add `text-foreground` class to h1 headings in dashboard and status pages for explicit foreground color styling
- Update breadcrumb link styling with `text-foreground/70` base color and `hover:text-foreground` on interaction
- Add `text-foreground/50` opacity class to breadcrumb separator icons for improved visual hierarchy