### PR TITLE
refactor(streams): remove debugging logs and unused functions

### DIFF
--- a/apps/client/app/(no-navbar)/status/page.tsx
+++ b/apps/client/app/(no-navbar)/status/page.tsx
@@ -195,8 +195,10 @@ export default function StatusPage() {
   const processedWebsites = useMemo(() => {
     if (!statusQuery.data?.websites) return [];
     return statusQuery.data.websites.map((website) => {
-      const websiteTrackerData = getTrackerData(website.statusPoints);
-      const hasData = websiteTrackerData.length > 0;
+      const hasData = website.statusPoints.length > 0;
+      const websiteTrackerData = getTrackerData(
+        hasData ? website.statusPoints : [],
+      );
       const hasCloudflareBlock = website.currentStatus?.httpStatusCode === 403;
 
       return {

--- a/apps/worker/src/index.ts
+++ b/apps/worker/src/index.ts
@@ -4,13 +4,7 @@ import {
   type UptimeStatus,
 } from "@repo/clickhouse";
 import { REGION_ID, WORKER_ID } from "@repo/config";
-import {
-  xAckBulk,
-  xReadGroup,
-  xReadGroupPending,
-  xAutoClaimStale,
-  xPendingDiagnostic,
-} from "@repo/streams";
+import { xAckBulk, xReadGroup, xAutoClaimStale } from "@repo/streams";
 import axios from "axios";
 import process from "node:process";
 
@@ -78,24 +72,6 @@ async function startWorker() {
     )})`,
   );
 
-  // #region agent log
-  fetch("http://127.0.0.1:7243/ingest/4d066341-b328-4de4-954f-033a4efeb773", {
-    method: "POST",
-    headers: { "Content-Type": "application/json" },
-    body: JSON.stringify({
-      sessionId: "debug-session",
-      runId: "run1",
-      hypothesisId: "E",
-      location: "apps/worker/src/index.ts:startWorker",
-      message: "Worker starting",
-      data: { regionId: REGION_ID, workerId: WORKER_ID },
-      timestamp: Date.now(),
-    }),
-  }).catch(() => {});
-  // Run diagnostic to check for pending messages
-  await xPendingDiagnostic(REGION_ID);
-  // #endregion
-
   // Drain any *stale pending* (already-delivered but unacked) messages first so
   // we don't leave older websites permanently stuck on dead consumers. We use
   // XAUTOCLAIM underneath so we can take over messages from other consumers.
@@ -151,7 +127,6 @@ async function startWorker() {
     }
   }
 
-  let loopCount = 0;
   while (true) {
     const response = await xReadGroup({
       consumerGroup: REGION_ID,
@@ -201,30 +176,6 @@ async function startWorker() {
     // Safety: keep a small delay to avoid tight loop if xReadGroup returns immediately.
     // (We may remove this after verifying blocking behavior via logs.)
     await new Promise((resolve) => setTimeout(resolve, 1000));
-    loopCount++;
-
-    // #region agent log
-    // Run diagnostic every 10 loops to track pending message state
-    if (loopCount % 10 === 0) {
-      await xPendingDiagnostic(REGION_ID);
-      fetch(
-        "http://127.0.0.1:7243/ingest/4d066341-b328-4de4-954f-033a4efeb773",
-        {
-          method: "POST",
-          headers: { "Content-Type": "application/json" },
-          body: JSON.stringify({
-            sessionId: "debug-session",
-            runId: "run1",
-            hypothesisId: "A",
-            location: "apps/worker/src/index.ts:loopCheckpoint",
-            message: "Worker loop checkpoint",
-            data: { loopCount, regionId: REGION_ID, workerId: WORKER_ID },
-            timestamp: Date.now(),
-          }),
-        },
-      ).catch(() => {});
-    }
-    // #endregion
   }
 }
 

--- a/packages/streams/src/index.ts
+++ b/packages/streams/src/index.ts
@@ -82,34 +82,7 @@ try {
   process.exit(1);
 }
 
-async function xAdd({ url, id }: WebsiteEvent) {
-  await client.xAdd(STREAM_NAME, "*", {
-    url,
-    id,
-  });
-}
-
 export async function xAddBulk(websites: WebsiteEvent[]) {
-  // #region agent log
-  fetch("http://127.0.0.1:7243/ingest/4d066341-b328-4de4-954f-033a4efeb773", {
-    method: "POST",
-    headers: { "Content-Type": "application/json" },
-    body: JSON.stringify({
-      sessionId: "debug-session",
-      runId: "run1",
-      hypothesisId: "E",
-      location: "packages/streams/src/index.ts:xAddBulk:entry",
-      message: "xAddBulk called",
-      data: {
-        streamName: STREAM_NAME,
-        websiteCount: websites.length,
-        websiteIds: websites.slice(0, 50).map((w) => w.id),
-      },
-      timestamp: Date.now(),
-    }),
-  }).catch(() => {});
-  // #endregion
-
   // Avoid unbounded Promise.all fan-out (can freeze machines with large website counts).
   // Use Redis pipelining in bounded batches.
   const batchSize = 250;
@@ -124,26 +97,6 @@ export async function xAddBulk(websites: WebsiteEvent[]) {
     if (res === null) {
       throw new Error("Redis MULTI exec returned null (disconnected?)");
     }
-    // #region agent log
-    fetch("http://127.0.0.1:7243/ingest/4d066341-b328-4de4-954f-033a4efeb773", {
-      method: "POST",
-      headers: { "Content-Type": "application/json" },
-      body: JSON.stringify({
-        sessionId: "debug-session",
-        runId: "run1",
-        hypothesisId: "E",
-        location: "packages/streams/src/index.ts:xAddBulk:batchDone",
-        message: "xAddBulk batch published",
-        data: {
-          streamName: STREAM_NAME,
-          batchIndex: i,
-          batchSize: batch.length,
-          resIsNull: res === null,
-        },
-        timestamp: Date.now(),
-      }),
-    }).catch(() => {});
-    // #endregion
   }
 }
 
@@ -151,26 +104,6 @@ export async function xReadGroup(
   options: ReadGroupOptions,
 ): Promise<MessageType[]> {
   try {
-    // #region agent log
-    fetch("http://127.0.0.1:7243/ingest/4d066341-b328-4de4-954f-033a4efeb773", {
-      method: "POST",
-      headers: { "Content-Type": "application/json" },
-      body: JSON.stringify({
-        sessionId: "debug-session",
-        runId: "run1",
-        hypothesisId: "A,B,C,E",
-        location: "packages/streams/src/index.ts:xReadGroup:entry",
-        message: "xReadGroup called",
-        data: {
-          streamName: STREAM_NAME,
-          consumerGroup: options.consumerGroup,
-          workerId: options.workerId,
-        },
-        timestamp: Date.now(),
-      }),
-    }).catch(() => {});
-    // #endregion
-
     const response = (await client.xReadGroup(
       options.consumerGroup,
       options.workerId,
@@ -186,46 +119,7 @@ export async function xReadGroup(
       },
     )) as StreamReadResponse[];
 
-    // #region agent log
-    fetch("http://127.0.0.1:7243/ingest/4d066341-b328-4de4-954f-033a4efeb773", {
-      method: "POST",
-      headers: { "Content-Type": "application/json" },
-      body: JSON.stringify({
-        sessionId: "debug-session",
-        runId: "run1",
-        hypothesisId: "A,C,D",
-        location: "packages/streams/src/index.ts:xReadGroup:afterRead",
-        message: "xReadGroup returned",
-        data: {
-          streamName: STREAM_NAME,
-          responseExists: !!response,
-          responseLength: response?.length,
-          firstStreamMessages: response?.[0]?.messages?.length,
-        },
-        timestamp: Date.now(),
-      }),
-    }).catch(() => {});
-    // #endregion
-
     if (!response || response.length === 0 || !response[0]?.messages) {
-      // #region agent log
-      fetch(
-        "http://127.0.0.1:7243/ingest/4d066341-b328-4de4-954f-033a4efeb773",
-        {
-          method: "POST",
-          headers: { "Content-Type": "application/json" },
-          body: JSON.stringify({
-            sessionId: "debug-session",
-            runId: "run1",
-            hypothesisId: "A,C",
-            location: "packages/streams/src/index.ts:xReadGroup:empty",
-            message: "xReadGroup empty response",
-            data: { streamName: STREAM_NAME, responseType: typeof response },
-            timestamp: Date.now(),
-          }),
-        },
-      ).catch(() => {});
-      // #endregion
       return [];
     }
 
@@ -243,181 +137,9 @@ export async function xReadGroup(
         },
       }));
 
-    // #region agent log
-    fetch("http://127.0.0.1:7243/ingest/4d066341-b328-4de4-954f-033a4efeb773", {
-      method: "POST",
-      headers: { "Content-Type": "application/json" },
-      body: JSON.stringify({
-        sessionId: "debug-session",
-        runId: "run1",
-        hypothesisId: "D",
-        location: "packages/streams/src/index.ts:xReadGroup:processed",
-        message: "xReadGroup processed messages",
-        data: {
-          streamName: STREAM_NAME,
-          rawCount: rawMessages.length,
-          filteredCount: messages.length,
-          filteredOut: rawMessages.length - messages.length,
-          messageIds: messages.map((m) => m.event.id),
-        },
-        timestamp: Date.now(),
-      }),
-    }).catch(() => {});
-    // #endregion
-
     return messages;
   } catch (error) {
-    // #region agent log
-    fetch("http://127.0.0.1:7243/ingest/4d066341-b328-4de4-954f-033a4efeb773", {
-      method: "POST",
-      headers: { "Content-Type": "application/json" },
-      body: JSON.stringify({
-        sessionId: "debug-session",
-        runId: "run1",
-        hypothesisId: "B,C",
-        location: "packages/streams/src/index.ts:xReadGroup:error",
-        message: "xReadGroup threw",
-        data: {
-          streamName: STREAM_NAME,
-          errorName: (error as Error)?.name,
-          errorMessage: (error as Error)?.message,
-        },
-        timestamp: Date.now(),
-      }),
-    }).catch(() => {});
-    // #endregion
     console.error("Error reading from stream:", error);
-    return [];
-  }
-}
-
-// Read *pending* (already-delivered but unacked) messages for a specific
-// consumer in a group. Note: in Redis, pending messages are *owned* by the
-// consumer that first saw them. If that consumer is gone, we must use
-// XAUTOCLAIM instead (see xAutoClaimStale below).
-export async function xReadGroupPending(
-  options: ReadGroupOptions,
-): Promise<MessageType[]> {
-  try {
-    // #region agent log
-    fetch("http://127.0.0.1:7243/ingest/4d066341-b328-4de4-954f-033a4efeb773", {
-      method: "POST",
-      headers: { "Content-Type": "application/json" },
-      body: JSON.stringify({
-        sessionId: "debug-session",
-        runId: "run1",
-        hypothesisId: "A",
-        location: "packages/streams/src/index.ts:xReadGroupPending:entry",
-        message: "xReadGroupPending called",
-        data: {
-          streamName: STREAM_NAME,
-          consumerGroup: options.consumerGroup,
-          workerId: options.workerId,
-        },
-        timestamp: Date.now(),
-      }),
-    }).catch(() => {});
-    // #endregion
-
-    const response = (await client.xReadGroup(
-      options.consumerGroup,
-      options.workerId,
-      {
-        key: STREAM_NAME,
-        // "0" means: start from the beginning of the pending entries list
-        // (already-delivered but unacked messages).
-        id: "0",
-      },
-      {
-        COUNT: 50,
-        BLOCK: 0,
-      },
-    )) as StreamReadResponse[] | null;
-
-    // #region agent log
-    fetch("http://127.0.0.1:7243/ingest/4d066341-b328-4de4-954f-033a4efeb773", {
-      method: "POST",
-      headers: { "Content-Type": "application/json" },
-      body: JSON.stringify({
-        sessionId: "debug-session",
-        runId: "run1",
-        hypothesisId: "A",
-        location: "packages/streams/src/index.ts:xReadGroupPending:afterRead",
-        message: "xReadGroupPending returned",
-        data: {
-          streamName: STREAM_NAME,
-          responseExists: !!response,
-          responseLength: response?.length ?? 0,
-          firstStreamMessages: response?.[0]?.messages?.length ?? 0,
-        },
-        timestamp: Date.now(),
-      }),
-    }).catch(() => {});
-    // #endregion
-
-    if (!response || response.length === 0 || !response[0]?.messages) {
-      return [];
-    }
-
-    const rawMessages = response[0].messages;
-    const messages: MessageType[] = rawMessages
-      .filter(
-        (streamMessage: StreamMessage) =>
-          streamMessage.message.url && streamMessage.message.id,
-      )
-      .map((streamMessage: StreamMessage) => ({
-        id: streamMessage.id,
-        event: {
-          url: streamMessage.message.url as string,
-          id: streamMessage.message.id as string,
-        },
-      }));
-
-    // #region agent log
-    fetch("http://127.0.0.1:7243/ingest/4d066341-b328-4de4-954f-033a4efeb773", {
-      method: "POST",
-      headers: { "Content-Type": "application/json" },
-      body: JSON.stringify({
-        sessionId: "debug-session",
-        runId: "run1",
-        hypothesisId: "A",
-        location: "packages/streams/src/index.ts:xReadGroupPending:processed",
-        message: "xReadGroupPending processed messages",
-        data: {
-          streamName: STREAM_NAME,
-          rawCount: rawMessages.length,
-          filteredCount: messages.length,
-          filteredOut: rawMessages.length - messages.length,
-          messageIds: messages.map((m) => m.event.id),
-        },
-        timestamp: Date.now(),
-      }),
-    }).catch(() => {});
-    // #endregion
-
-    return messages;
-  } catch (error) {
-    // #region agent log
-    fetch("http://127.0.0.1:7243/ingest/4d066341-b328-4de4-954f-033a4efeb773", {
-      method: "POST",
-      headers: { "Content-Type": "application/json" },
-      body: JSON.stringify({
-        sessionId: "debug-session",
-        runId: "run1",
-        hypothesisId: "A",
-        location: "packages/streams/src/index.ts:xReadGroupPending:error",
-        message: "xReadGroupPending threw",
-        data: {
-          streamName: STREAM_NAME,
-          errorName: (error as Error)?.name,
-          errorMessage: (error as Error)?.message,
-        },
-        timestamp: Date.now(),
-      }),
-    }).catch(() => {});
-    // #endregion
-
-    console.error("Error reading pending from stream:", error);
     return [];
   }
 }
@@ -429,28 +151,6 @@ export async function xAutoClaimStale(
   options: AutoClaimOptions,
 ): Promise<MessageType[]> {
   try {
-    // #region agent log
-    fetch("http://127.0.0.1:7243/ingest/4d066341-b328-4de4-954f-033a4efeb773", {
-      method: "POST",
-      headers: { "Content-Type": "application/json" },
-      body: JSON.stringify({
-        sessionId: "debug-session",
-        runId: "run1",
-        hypothesisId: "A",
-        location: "packages/streams/src/index.ts:xAutoClaimStale:entry",
-        message: "xAutoClaimStale called",
-        data: {
-          streamName: STREAM_NAME,
-          consumerGroup: options.consumerGroup,
-          workerId: options.workerId,
-          minIdleMs: options.minIdleMs,
-          count: options.count,
-        },
-        timestamp: Date.now(),
-      }),
-    }).catch(() => {});
-    // #endregion
-
     // node-redis XAUTOCLAIM returns: [messages, nextStartId]
     const result = (await client.xAutoClaim(
       STREAM_NAME,
@@ -464,26 +164,6 @@ export async function xAutoClaimStale(
     )) as unknown as { messages: StreamMessage[]; nextId: string };
 
     const claimedMessages = result?.messages ?? null;
-
-    // #region agent log
-    fetch("http://127.0.0.1:7243/ingest/4d066341-b328-4de4-954f-033a4efeb773", {
-      method: "POST",
-      headers: { "Content-Type": "application/json" },
-      body: JSON.stringify({
-        sessionId: "debug-session",
-        runId: "run1",
-        hypothesisId: "A",
-        location: "packages/streams/src/index.ts:xAutoClaimStale:afterClaim",
-        message: "xAutoClaimStale result",
-        data: {
-          streamName: STREAM_NAME,
-          hasResult: !!result,
-          claimedCount: claimedMessages ? claimedMessages.length : 0,
-        },
-        timestamp: Date.now(),
-      }),
-    }).catch(() => {});
-    // #endregion
 
     if (!claimedMessages || claimedMessages.length === 0) {
       return [];
@@ -502,50 +182,8 @@ export async function xAutoClaimStale(
         },
       }));
 
-    // #region agent log
-    fetch("http://127.0.0.1:7243/ingest/4d066341-b328-4de4-954f-033a4efeb773", {
-      method: "POST",
-      headers: { "Content-Type": "application/json" },
-      body: JSON.stringify({
-        sessionId: "debug-session",
-        runId: "run1",
-        hypothesisId: "A",
-        location: "packages/streams/src/index.ts:xAutoClaimStale:processed",
-        message: "xAutoClaimStale processed messages",
-        data: {
-          streamName: STREAM_NAME,
-          claimedCount: claimedMessages.length,
-          filteredCount: messages.length,
-          filteredOut: claimedMessages.length - messages.length,
-          messageIds: messages.map((m) => m.event.id),
-        },
-        timestamp: Date.now(),
-      }),
-    }).catch(() => {});
-    // #endregion
-
     return messages;
   } catch (error) {
-    // #region agent log
-    fetch("http://127.0.0.1:7243/ingest/4d066341-b328-4de4-954f-033a4efeb773", {
-      method: "POST",
-      headers: { "Content-Type": "application/json" },
-      body: JSON.stringify({
-        sessionId: "debug-session",
-        runId: "run1",
-        hypothesisId: "A",
-        location: "packages/streams/src/index.ts:xAutoClaimStale:error",
-        message: "xAutoClaimStale threw",
-        data: {
-          streamName: STREAM_NAME,
-          errorName: (error as Error)?.name,
-          errorMessage: (error as Error)?.message,
-        },
-        timestamp: Date.now(),
-      }),
-    }).catch(() => {});
-    // #endregion
-
     console.error("Error auto-claiming stale messages:", error);
     return [];
   }
@@ -572,66 +210,3 @@ export async function xAckBulk(options: AckBulkOptions) {
     ),
   );
 }
-
-// #region agent log - diagnostic function
-export async function xPendingDiagnostic(consumerGroup: string): Promise<void> {
-  try {
-    // Get pending summary for the consumer group
-    const pendingSummary = await client.xPending(STREAM_NAME, consumerGroup);
-    // Get stream length
-    const streamLen = await client.xLen(STREAM_NAME);
-    // Get stream info
-    const streamInfo = (await client.xInfoStream(STREAM_NAME)) as unknown as {
-      length: number;
-      "radix-tree-keys": number;
-      "radix-tree-nodes": number;
-      "last-generated-id": string;
-      "entries-added": number;
-      groups: number;
-      "first-entry": { id: string } | null;
-      "last-entry": { id: string } | null;
-    };
-
-    fetch("http://127.0.0.1:7243/ingest/4d066341-b328-4de4-954f-033a4efeb773", {
-      method: "POST",
-      headers: { "Content-Type": "application/json" },
-      body: JSON.stringify({
-        sessionId: "debug-session",
-        runId: "run1",
-        hypothesisId: "A,B",
-        location: "packages/streams/src/index.ts:xPendingDiagnostic",
-        message: "Stream diagnostics",
-        data: {
-          streamName: STREAM_NAME,
-          consumerGroup,
-          streamLength: streamLen,
-          pendingSummary: String(JSON.stringify(pendingSummary)).slice(0, 800),
-          firstEntry: streamInfo?.["first-entry"]?.id ?? null,
-          lastEntry: streamInfo?.["last-entry"]?.id ?? null,
-          groups: streamInfo?.groups,
-        },
-        timestamp: Date.now(),
-      }),
-    }).catch(() => {});
-  } catch (error) {
-    fetch("http://127.0.0.1:7243/ingest/4d066341-b328-4de4-954f-033a4efeb773", {
-      method: "POST",
-      headers: { "Content-Type": "application/json" },
-      body: JSON.stringify({
-        sessionId: "debug-session",
-        runId: "run1",
-        hypothesisId: "A,B,C",
-        location: "packages/streams/src/index.ts:xPendingDiagnostic:error",
-        message: "Stream diagnostics error",
-        data: {
-          streamName: STREAM_NAME,
-          consumerGroup,
-          errorName: (error as Error)?.name,
-          errorMessage: (error as Error)?.message,
-        },
-        timestamp: Date.now(),
-      }),
-    }).catch(() => {});
-  }
-}
-// #endregion


### PR DESCRIPTION
chore(client): optimize status page tracker data computation
- Check statusPoints length before calling getTrackerData
- Pass empty array when no data to avoid unnecessary processing

refactor(worker): cleanup unused imports and variables
- Remove xReadGroupPending, xPendingDiagnostic imports
- Remove loopCount variable and related logic

refactor(streams): remove extensive agent logging
- Eliminate all fetch calls to localhost:7243/ingest endpoint
- Remove xReadGroupPending and xPendingDiagnostic functions entirely