### PR TITLE
fix(uptime): improve error handling, auth flows, and stream processing

### DIFF
--- a/apps/client/app/(main)/dashboard/page.tsx
+++ b/apps/client/app/(main)/dashboard/page.tsx
@@ -70,12 +70,20 @@ export default function DashboardPage() {
   });
 
   useEffect(() => {
-    if (websitesQuery.error) {
-      toast.error("Failed to load websites", {
-        description: getErrorMessage(websitesQuery.error),
-      });
+    // Never toast error for empty data - these are NOT errors:
+    // - No websites (cold start user)
+    // - Empty data is valid state
+    if (websitesQuery.error && websitesQuery.data === undefined) {
+      // Only show error if we don't have any data (not just empty array)
+      const errorMessage = getErrorMessage(websitesQuery.error);
+      // Don't show error for UNAUTHORIZED - it's handled by trpc client
+      if (!errorMessage.toLowerCase().includes("unauthorized")) {
+        toast.error("Failed to load websites", {
+          description: errorMessage,
+        });
+      }
     }
-  }, [websitesQuery.error]);
+  }, [websitesQuery.error, websitesQuery.data]);
 
   const registerWebsite = trpc.website.register.useMutation({
     onSuccess: async () => {

--- a/apps/client/app/(no-navbar)/status/page.tsx
+++ b/apps/client/app/(no-navbar)/status/page.tsx
@@ -55,12 +55,21 @@ export default function StatusPage() {
   });
 
   useEffect(() => {
-    if (statusQuery.error) {
-      toast.error("Failed to load status", {
-        description: getErrorMessage(statusQuery.error),
-      });
+    // Never toast error for empty data - these are NOT errors:
+    // - No websites
+    // - No statusPoints yet (cold start user)
+    // - Empty data is valid state
+    if (statusQuery.error && statusQuery.data === undefined) {
+      // Only show error if we don't have any data (not just empty array)
+      const errorMessage = getErrorMessage(statusQuery.error);
+      // Don't show error for UNAUTHORIZED - it's handled by trpc client
+      if (!errorMessage.toLowerCase().includes("unauthorized")) {
+        toast.error("Failed to load status", {
+          description: errorMessage,
+        });
+      }
     }
-  }, [statusQuery.error]);
+  }, [statusQuery.error, statusQuery.data]);
 
   const buildStatusBadge = (
     currentStatus:

--- a/apps/client/app/lib/trpc.ts
+++ b/apps/client/app/lib/trpc.ts
@@ -24,6 +24,21 @@ export function getTrpcClient() {
               : null;
           return token ? { Authorization: `Bearer ${token}` } : {};
         },
+        async fetch(url, options) {
+          const response = await fetch(url, options);
+
+          // On 401 UNAUTHORIZED → force logout
+          if (response.status === 401) {
+            if (typeof window !== "undefined") {
+              localStorage.removeItem("token");
+              window.dispatchEvent(new Event("auth-change"));
+              // Redirect to login
+              window.location.href = "/login";
+            }
+          }
+
+          return response;
+        },
       }),
     ],
   });

--- a/apps/publisher/src/index.ts
+++ b/apps/publisher/src/index.ts
@@ -9,7 +9,12 @@ async function publish() {
   }
   inFlight = true;
   try {
+    // Always fetch fresh websites - never cache, never startup-only
+    // Filter by isActive to only publish active websites
     const websites = await prismaClient.website.findMany({
+      where: {
+        isActive: true,
+      },
       select: {
         url: true,
         id: true,
@@ -17,11 +22,13 @@ async function publish() {
     });
 
     if (websites.length === 0) {
-      console.log(`[Publisher] No websites found in database`);
+      console.log(`[Publisher] No active websites found in database`);
       return;
     }
 
-    console.log(`[Publisher] Found ${websites.length} website(s) to publish`);
+    console.log(
+      `[Publisher] Found ${websites.length} active website(s) to publish`,
+    );
 
     await xAddBulk(websites.map((w) => ({ url: w.url, id: w.id })));
 
@@ -35,10 +42,10 @@ async function publish() {
   }
 }
 
-console.log(`[Publisher] Starting publisher service (interval: 2m)`);
+console.log(`[Publisher] Starting publisher service (interval: 3m)`);
 setInterval(
   () => {
     publish();
   },
-  2 * 60 * 1000,
-); // push to the stream, every 2 mins
+  3 * 60 * 1000,
+); // push to the stream, every 3 mins

--- a/packages/api/package.json
+++ b/packages/api/package.json
@@ -31,6 +31,7 @@
     "@repo/clickhouse": "workspace:*",
     "@repo/config": "workspace:*",
     "@repo/store": "workspace:*",
+    "@repo/streams": "workspace:*",
     "@repo/validators": "workspace:*",
     "@trpc/client": "^11.8.1",
     "@trpc/server": "^11.8.1",

--- a/packages/api/src/__tests__/routes/website.test.ts
+++ b/packages/api/src/__tests__/routes/website.test.ts
@@ -278,11 +278,12 @@ describe("Website Routes", () => {
 
       expect(result.success).toBe(true);
 
-      // Verify deletion
+      // Verify soft deletion (isActive = false, not hard delete)
       const deleted = await prismaClient.website.findUnique({
         where: { id: website.id },
       });
-      expect(deleted).toBeNull();
+      expect(deleted).not.toBeNull();
+      expect(deleted?.isActive).toBe(false);
     });
 
     it("should fail if website belongs to another user", async () => {

--- a/packages/streams/src/index.ts
+++ b/packages/streams/src/index.ts
@@ -59,30 +59,44 @@ export interface AutoClaimOptions {
   count: number;
 }
 
-const redisClient = createClient({
-  username: REDIS_USERNAME,
-  password: REDIS_PASSWORD,
-  socket: {
-    host: REDIS_HOST,
-    port: Number(REDIS_PORT),
-  },
-});
+// In test environment, skip Redis connection and use mocks
+const isTestEnv = process.env.NODE_ENV === "test";
 
-redisClient.on("error", (err) => {
-  console.error("Redis Client Error", err);
-  process.exit(1);
-});
+let client: ReturnType<typeof createClient> | null = null;
 
-let client: typeof redisClient;
+if (!isTestEnv) {
+  const redisClient = createClient({
+    username: REDIS_USERNAME,
+    password: REDIS_PASSWORD,
+    socket: {
+      host: REDIS_HOST,
+      port: Number(REDIS_PORT),
+    },
+  });
 
-try {
-  client = await redisClient.connect();
-} catch (error) {
-  console.error("Failed to connect to Redis:", error);
-  process.exit(1);
+  redisClient.on("error", (err) => {
+    console.error("Redis Client Error", err);
+    process.exit(1);
+  });
+
+  try {
+    client = await redisClient.connect();
+  } catch (error) {
+    console.error("Failed to connect to Redis:", error);
+    process.exit(1);
+  }
 }
 
 export async function xAddBulk(websites: WebsiteEvent[]) {
+  // Mock in test environment
+  if (isTestEnv) {
+    return;
+  }
+
+  if (!client) {
+    throw new Error("Redis client not initialized");
+  }
+
   // Avoid unbounded Promise.all fan-out (can freeze machines with large website counts).
   // Use Redis pipelining in bounded batches.
   const batchSize = 250;
@@ -103,6 +117,15 @@ export async function xAddBulk(websites: WebsiteEvent[]) {
 export async function xReadGroup(
   options: ReadGroupOptions,
 ): Promise<MessageType[]> {
+  // Mock in test environment
+  if (isTestEnv) {
+    return [];
+  }
+
+  if (!client) {
+    throw new Error("Redis client not initialized");
+  }
+
   try {
     const response = (await client.xReadGroup(
       options.consumerGroup,
@@ -149,6 +172,15 @@ export async function xReadGroup(
 export async function xAutoClaimStale(
   options: AutoClaimOptions,
 ): Promise<MessageType[]> {
+  // Mock in test environment
+  if (isTestEnv) {
+    return [];
+  }
+
+  if (!client) {
+    throw new Error("Redis client not initialized");
+  }
+
   try {
     // node-redis XAUTOCLAIM returns: [messages, nextStartId]
     const result = (await client.xAutoClaim(
@@ -189,6 +221,15 @@ export async function xAutoClaimStale(
 }
 
 async function xAck(options: AckOptions): Promise<number> {
+  // Mock in test environment
+  if (isTestEnv) {
+    return 1;
+  }
+
+  if (!client) {
+    throw new Error("Redis client not initialized");
+  }
+
   try {
     const result = await client.xAck(
       STREAM_NAME,
@@ -203,6 +244,11 @@ async function xAck(options: AckOptions): Promise<number> {
 }
 
 export async function xAckBulk(options: AckBulkOptions) {
+  // Mock in test environment
+  if (isTestEnv) {
+    return;
+  }
+
   await Promise.all(
     options.eventIds.map((eventId) =>
       xAck({ consumerGroup: options.consumerGroup, streamId: eventId }),
@@ -226,6 +272,19 @@ export interface PendingInfo {
 export async function xPendingInfo(
   consumerGroup: string,
 ): Promise<PendingInfo> {
+  // Mock in test environment
+  if (isTestEnv) {
+    return {
+      pending: 0,
+      oldestIdleMs: null,
+      consumers: [],
+    };
+  }
+
+  if (!client) {
+    throw new Error("Redis client not initialized");
+  }
+
   try {
     // Get summary (pending count, first/last IDs, consumers)
     const summary = (await client.xPending(

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -276,6 +276,9 @@ importers:
       '@repo/store':
         specifier: workspace:*
         version: link:../store
+      '@repo/streams':
+        specifier: workspace:*
+        version: link:../streams
       '@repo/validators':
         specifier: workspace:*
         version: link:../validators


### PR DESCRIPTION
- refine useEffect error toasts: only show on true failures (data===undefined, exclude unauthorized, empty arrays valid)
- add trpc 401 handling: force logout + redirect to /login on unauthorized
- implement soft delete (isActive=false): filter inactive sites from publisher/worker/queries
- enhance worker PEL: monitoring, validation before processing, immediate ACK invalid sites
- add immediate publish on website.register + PEL status monitoring (5min intervals)
- increase publisher interval to 3min, worker stale claim batch to 10
- refine useEffect error toasts: only show on true failures (data===undefined, exclude unauthorized, empty