### PR TITLE
feat(status-pages): implement full status page creation with custom domain verification

### DIFF
--- a/apps/client/app/(main)/dashboard/status-pages/new/page.tsx
+++ b/apps/client/app/(main)/dashboard/status-pages/new/page.tsx
@@ -3,20 +3,70 @@
 import { useState } from "react";
 import { useRouter } from "next/navigation";
 import Link from "next/link";
-import { ArrowLeft } from "lucide-react";
+import { toast } from "sonner";
+import { ArrowLeft, Loader2, ShieldCheck } from "lucide-react";
 import { Button } from "@/components/Button";
 import { Input } from "@/components/Input";
 import { Label } from "@/components/Label";
 import { trpc } from "@/lib/trpc";
 
+function getErrorMessage(error: { message: string }): string {
+  try {
+    const parsed = JSON.parse(error.message);
+    if (Array.isArray(parsed) && parsed.length > 0 && parsed[0].message) {
+      return parsed[0].message;
+    }
+  } catch {
+    // Keep original message when payload is not JSON.
+  }
+  return error.message;
+}
+
 export default function NewStatusPage() {
   const router = useRouter();
+  const utils = trpc.useUtils();
   const [name, setName] = useState("");
   const [slug, setSlug] = useState("");
+  const [hostname, setHostname] = useState("");
+  const [createdStatusPageId, setCreatedStatusPageId] = useState<string | null>(
+    null,
+  );
+  const [dnsInstructions, setDnsInstructions] = useState<{
+    statusPageId: string;
+    hostname: string;
+    verificationStatus: "PENDING" | "VERIFIED" | "FAILED";
+    cnameRecordName: string;
+    cnameRecordValue: string;
+    txtRecordName: string;
+    txtRecordValue: string;
+  } | null>(null);
 
-  // Use status query to get monitors list for selection
+  // Use monitor status query to get monitor list for selection.
   const websitesQuery = trpc.website.status.useQuery(undefined, {
     retry: false,
+  });
+
+  const createStatusPage = trpc.statusPage.create.useMutation();
+  const requestVerification =
+    trpc.statusDomain.requestVerification.useMutation();
+  const verifyDomain = trpc.statusDomain.verify.useMutation({
+    onSuccess: async (result) => {
+      if (result.verificationStatus === "VERIFIED") {
+        toast.success("Domain verified", {
+          description: `${result.hostname} is now active.`,
+        });
+        await utils.statusPage.list.invalidate();
+      } else {
+        toast.error("Verification failed", {
+          description: "DNS records are not ready yet. Try again in a minute.",
+        });
+      }
+    },
+    onError: (error) => {
+      toast.error("Could not verify domain", {
+        description: getErrorMessage(error),
+      });
+    },
   });
 
   const websites = websitesQuery.data?.websites ?? [];
@@ -28,11 +78,38 @@ export default function NewStatusPage() {
     );
   };
 
-  const handleSubmit = (e: React.FormEvent) => {
+  const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
-    // TODO: Implement actual creation
-    console.log("Creating status page:", { name, slug, selectedMonitors });
-    router.push("/dashboard/status-pages");
+
+    if (selectedMonitors.length === 0) {
+      toast.error("Select at least one monitor");
+      return;
+    }
+
+    try {
+      const statusPage = await createStatusPage.mutateAsync({
+        name,
+        slug,
+        monitorIds: selectedMonitors,
+        isPublished: true,
+      });
+      setCreatedStatusPageId(statusPage.id);
+
+      const verification = await requestVerification.mutateAsync({
+        statusPageId: statusPage.id,
+        hostname,
+      });
+      setDnsInstructions(verification);
+
+      toast.success("Status page created", {
+        description: "Add the DNS records below, then run verification.",
+      });
+      await utils.statusPage.list.invalidate();
+    } catch (error) {
+      toast.error("Could not create status page", {
+        description: getErrorMessage(error as { message: string }),
+      });
+    }
   };
 
   return (
@@ -46,17 +123,17 @@ export default function NewStatusPage() {
           <ArrowLeft className="mr-1 size-4" />
           Back to Status Pages
         </Link>
-        <h1 className="text-3xl font-bold tracking-tight text-[var(--foreground)]">
+        <h1 className="text-3xl font-bold tracking-tight text-foreground">
           Create Status Page
         </h1>
       </div>
 
       <form onSubmit={handleSubmit} className="space-y-8">
         {/* Page Details */}
-        <div className="rounded-xl border border-border bg-white p-6 shadow-sm dark:bg-card">
+        <div className="rounded-xl border border-border bg-card p-6 shadow-sm">
           <h2 className="mb-4 text-lg font-semibold">Page Details</h2>
           <p className="mb-4 text-sm text-muted-foreground">
-            Basic information about your public status page.
+            Configure your public status page and custom hostname.
           </p>
 
           <div className="space-y-4">
@@ -72,10 +149,10 @@ export default function NewStatusPage() {
             </div>
 
             <div className="space-y-2">
-              <Label htmlFor="slug">URL Slug</Label>
+              <Label htmlFor="slug">Internal Slug</Label>
               <div className="flex rounded-md shadow-sm">
                 <span className="inline-flex items-center rounded-l-md border border-r-0 border-input bg-muted px-3 text-sm text-muted-foreground">
-                  betterstack.com/status/
+                  status-page/
                 </span>
                 <Input
                   id="slug"
@@ -87,11 +164,25 @@ export default function NewStatusPage() {
                 />
               </div>
             </div>
+
+            <div className="space-y-2">
+              <Label htmlFor="hostname">Public Hostname</Label>
+              <Input
+                id="hostname"
+                placeholder="status.startup.com"
+                value={hostname}
+                onChange={(e) => setHostname(e.target.value)}
+                required
+              />
+              <p className="text-xs text-muted-foreground">
+                Use a hostname like <code>status.your-domain.com</code>.
+              </p>
+            </div>
           </div>
         </div>
 
         {/* Select Monitors */}
-        <div className="rounded-xl border border-border bg-white p-6 shadow-sm dark:bg-card">
+        <div className="rounded-xl border border-border bg-card p-6 shadow-sm">
           <h2 className="mb-4 text-lg font-semibold">Select Monitors</h2>
           <p className="mb-4 text-sm text-muted-foreground">
             Choose which monitors to display on this status page.
@@ -142,6 +233,83 @@ export default function NewStatusPage() {
           </p>
         </div>
 
+        {/* DNS Instructions */}
+        {dnsInstructions ? (
+          <div className="rounded-xl border border-primary-action/30 bg-primary-action/5 p-6">
+            <h2 className="mb-2 text-lg font-semibold text-foreground">
+              DNS Verification
+            </h2>
+            <p className="mb-4 text-sm text-muted-foreground">
+              Add the records below in your DNS provider, wait for propagation,
+              then verify.
+            </p>
+
+            <div className="space-y-4 text-sm">
+              <div className="rounded-md border border-border bg-background p-3">
+                <p className="font-medium">CNAME record</p>
+                <p className="mt-1 text-muted-foreground break-all">
+                  <span className="font-medium text-foreground">Name:</span>{" "}
+                  {dnsInstructions.cnameRecordName}
+                </p>
+                <p className="text-muted-foreground break-all">
+                  <span className="font-medium text-foreground">Value:</span>{" "}
+                  {dnsInstructions.cnameRecordValue}
+                </p>
+              </div>
+
+              <div className="rounded-md border border-border bg-background p-3">
+                <p className="font-medium">TXT record</p>
+                <p className="mt-1 text-muted-foreground break-all">
+                  <span className="font-medium text-foreground">Name:</span>{" "}
+                  {dnsInstructions.txtRecordName}
+                </p>
+                <p className="text-muted-foreground break-all">
+                  <span className="font-medium text-foreground">Value:</span>{" "}
+                  {dnsInstructions.txtRecordValue}
+                </p>
+              </div>
+            </div>
+
+            <div className="mt-5 flex flex-wrap gap-3">
+              <Button
+                type="button"
+                variant="primary"
+                onClick={() =>
+                  verifyDomain.mutate({
+                    statusPageId: dnsInstructions.statusPageId,
+                    hostname: dnsInstructions.hostname,
+                  })
+                }
+                disabled={verifyDomain.isPending}
+              >
+                {verifyDomain.isPending ? (
+                  <>
+                    <Loader2 className="mr-2 size-4 animate-spin" />
+                    Verifying...
+                  </>
+                ) : (
+                  "Verify DNS"
+                )}
+              </Button>
+
+              <Button
+                type="button"
+                variant="secondary"
+                onClick={() => router.push("/dashboard/status-pages")}
+              >
+                Go to Status Pages
+              </Button>
+            </div>
+
+            {verifyDomain.data?.verificationStatus === "VERIFIED" ? (
+              <div className="mt-4 inline-flex items-center gap-2 rounded-md border border-primary-action/30 bg-primary-action/10 px-3 py-2 text-sm text-primary-action">
+                <ShieldCheck className="size-4" />
+                Domain verified successfully.
+              </div>
+            ) : null}
+          </div>
+        ) : null}
+
         {/* Actions */}
         <div className="flex justify-end gap-3">
           <Button
@@ -151,7 +319,14 @@ export default function NewStatusPage() {
           >
             Cancel
           </Button>
-          <Button type="submit" variant="primary">
+          <Button
+            type="submit"
+            variant="primary"
+            isLoading={
+              createStatusPage.isPending || requestVerification.isPending
+            }
+            disabled={Boolean(createdStatusPageId)}
+          >
             Create Status Page
           </Button>
         </div>

--- a/apps/client/app/(main)/dashboard/status-pages/page.tsx
+++ b/apps/client/app/(main)/dashboard/status-pages/page.tsx
@@ -1,32 +1,56 @@
 "use client";
 
 import Link from "next/link";
+import { toast } from "sonner";
 import {
   ExternalLink,
   LayoutTemplate,
-  MoreHorizontal,
+  Loader2,
   Plus,
+  ShieldCheck,
 } from "lucide-react";
 import { Button } from "@/components/Button";
-import {
-  DropdownMenu,
-  DropdownMenuContent,
-  DropdownMenuItem,
-  DropdownMenuTrigger,
-} from "@/components/DropdownMenu";
+import { trpc } from "@/lib/trpc";
 
-// Mock data for initial UI implementation
-const MOCK_STATUS_PAGES = [
-  {
-    id: "1",
-    name: "Acme Inc. Status",
-    slug: "acme",
-    monitorCount: 3,
-    isPublished: true,
-  },
-];
+function getErrorMessage(error: { message: string }): string {
+  try {
+    const parsed = JSON.parse(error.message);
+    if (Array.isArray(parsed) && parsed.length > 0 && parsed[0].message) {
+      return parsed[0].message;
+    }
+  } catch {
+    // Keep original message when payload is not JSON.
+  }
+  return error.message;
+}
 
 export default function StatusPagesPage() {
+  const utils = trpc.useUtils();
+  const statusPagesQuery = trpc.statusPage.list.useQuery(undefined, {
+    retry: false,
+  });
+
+  const verifyDomain = trpc.statusDomain.verify.useMutation({
+    onSuccess: async (result) => {
+      if (result.verificationStatus === "VERIFIED") {
+        toast.success("Domain verified", {
+          description: `${result.hostname} is now active.`,
+        });
+      } else {
+        toast.error("Verification failed", {
+          description: "DNS records are not ready yet. Try again in a minute.",
+        });
+      }
+
+      await utils.statusPage.list.invalidate();
+    },
+    onError: (error) => {
+      toast.error("Could not verify domain", {
+        description: getErrorMessage(error),
+      });
+    },
+  });
+
   return (
     <div className="space-y-8 py-8">
       {/* Header */}
@@ -44,57 +68,119 @@ export default function StatusPagesPage() {
 
       {/* Pages Grid */}
       <div className="grid gap-6 px-6 sm:grid-cols-2 lg:grid-cols-3">
-        {MOCK_STATUS_PAGES.map((page) => (
-          <div
-            key={page.id}
-            className="group relative flex flex-col justify-between rounded-xl border border-border bg-card p-6 shadow-sm transition-all hover:border-primary-action/20 hover:shadow-md"
-          >
-            <div className="space-y-4">
-              <div className="flex items-start justify-between">
-                <div className="rounded-lg bg-primary-action/10 p-2 text-primary-action">
+        {statusPagesQuery.isLoading ? (
+          <div className="sm:col-span-2 lg:col-span-3 rounded-xl border border-border bg-card p-6 text-sm text-muted-foreground">
+            Loading status pages...
+          </div>
+        ) : statusPagesQuery.isError ? (
+          <div className="sm:col-span-2 lg:col-span-3 rounded-xl border border-destructive/30 bg-destructive/5 p-6 text-sm text-destructive">
+            {getErrorMessage(statusPagesQuery.error)}
+          </div>
+        ) : statusPagesQuery.data?.statusPages.length ? (
+          statusPagesQuery.data.statusPages.map((page) => (
+            <div
+              key={page.id}
+              className="group relative flex flex-col justify-between rounded-xl border border-border bg-card p-6 shadow-sm transition-all hover:border-primary-action/20 hover:shadow-md"
+            >
+              <div className="space-y-4">
+                <div className="rounded-lg bg-primary-action/10 p-2 text-primary-action w-fit">
                   <LayoutTemplate className="size-6" />
                 </div>
-                <DropdownMenu>
-                  <DropdownMenuTrigger asChild>
-                    <button className="flex size-8 items-center justify-center rounded-md text-muted-foreground transition-colors hover:bg-muted hover:text-foreground outline-none">
-                      <MoreHorizontal className="size-4" />
-                      <span className="sr-only">Actions</span>
-                    </button>
-                  </DropdownMenuTrigger>
-                  <DropdownMenuContent align="end">
-                    <DropdownMenuItem>Edit</DropdownMenuItem>
-                    <DropdownMenuItem className="text-destructive">
-                      Delete
-                    </DropdownMenuItem>
-                  </DropdownMenuContent>
-                </DropdownMenu>
-              </div>
 
-              <div>
-                <h3 className="font-semibold text-lg text-foreground">
-                  {page.name}
-                </h3>
-                <div className="mt-1 flex items-center gap-2 text-sm text-muted-foreground">
-                  <span className="rounded-md bg-muted px-1.5 py-0.5 font-mono text-xs">
-                    /{page.slug}
-                  </span>
-                  <span>•</span>
-                  <span>{page.monitorCount} monitors</span>
+                <div>
+                  <h3 className="font-semibold text-lg text-foreground">
+                    {page.name}
+                  </h3>
+                  <div className="mt-1 flex items-center gap-2 text-sm text-muted-foreground">
+                    <span className="rounded-md bg-muted px-1.5 py-0.5 font-mono text-xs">
+                      {page.slug}
+                    </span>
+                    <span>•</span>
+                    <span>{page.monitorCount} monitors</span>
+                  </div>
+                </div>
+
+                <div className="rounded-lg border border-border/70 bg-muted/20 p-3 text-sm">
+                  {page.domain ? (
+                    <>
+                      <div className="font-medium text-foreground break-all">
+                        {page.domain.hostname}
+                      </div>
+                      <div className="mt-1 flex items-center gap-2 text-xs">
+                        <span
+                          className={
+                            page.domain.verificationStatus === "VERIFIED"
+                              ? "text-primary-action"
+                              : "text-amber-600 dark:text-amber-400"
+                          }
+                        >
+                          {page.domain.verificationStatus}
+                        </span>
+                        {page.domain.verificationStatus === "VERIFIED" ? (
+                          <ShieldCheck className="size-3 text-primary-action" />
+                        ) : null}
+                      </div>
+                    </>
+                  ) : (
+                    <span className="text-muted-foreground">
+                      No domain configured yet.
+                    </span>
+                  )}
                 </div>
               </div>
-            </div>
 
-            <div className="mt-6 border-t border-border/50 pt-4">
-              <Link
-                href={`/status/${page.slug}`} // Assuming this route will exist
-                className="flex items-center text-sm font-medium text-primary-action hover:underline"
-              >
-                View Public Page
-                <ExternalLink className="ml-1.5 size-3" />
-              </Link>
+              <div className="mt-6 border-t border-border/50 pt-4 space-y-3">
+                {page.domain?.verificationStatus === "VERIFIED" ? (
+                  <a
+                    href={`https://${page.domain.hostname}`}
+                    target="_blank"
+                    rel="noreferrer"
+                    className="inline-flex items-center text-sm font-medium text-primary-action hover:underline"
+                  >
+                    View Public Page
+                    <ExternalLink className="ml-1.5 size-3" />
+                  </a>
+                ) : (
+                  <p className="text-sm text-muted-foreground">
+                    Verify DNS to activate your public status page.
+                  </p>
+                )}
+
+                {page.domain &&
+                page.domain.verificationStatus !== "VERIFIED" ? (
+                  <Button
+                    type="button"
+                    variant="secondary"
+                    className="w-full"
+                    onClick={() =>
+                      verifyDomain.mutate({
+                        statusPageId: page.id,
+                        hostname: page.domain!.hostname,
+                      })
+                    }
+                    disabled={verifyDomain.isPending}
+                  >
+                    {verifyDomain.isPending ? (
+                      <>
+                        <Loader2 className="mr-2 size-4 animate-spin" />
+                        Verifying...
+                      </>
+                    ) : (
+                      "Verify DNS"
+                    )}
+                  </Button>
+                ) : null}
+              </div>
             </div>
+          ))
+        ) : (
+          <div className="sm:col-span-2 lg:col-span-3 rounded-xl border border-border bg-card p-10 text-center">
+            <p className="text-sm text-muted-foreground">
+              No status pages yet. Create your first one to publish monitor
+              health.
+            </p>
           </div>
-        ))}
+        )}
 
         {/* Create Card (Alternative to button) */}
         <Link

--- a/apps/client/app/(no-navbar)/status/page.tsx
+++ b/apps/client/app/(no-navbar)/status/page.tsx
@@ -1,7 +1,31 @@
-"use client";
+import { headers } from "next/headers";
+import { PublicStatusOverview } from "@/components/status/PublicStatusOverview";
 
-import { StatusOverview } from "@/components/status/StatusOverview";
+function normalizeHostname(rawHost: string | null): string {
+  if (!rawHost) return "";
+  const [firstHost] = rawHost.split(",");
+  const host = firstHost?.trim().toLowerCase();
+  if (!host) return "";
+  return host.split(":")[0] || "";
+}
 
-export default function StatusPage() {
-  return <StatusOverview />;
+export default async function StatusPage({
+  searchParams,
+}: {
+  searchParams?: Promise<Record<string, string | string[] | undefined>>;
+}) {
+  const resolvedSearchParams = searchParams ? await searchParams : undefined;
+  const hostFromQuery = resolvedSearchParams?.hostname;
+  const hostnameFromQuery =
+    typeof hostFromQuery === "string" ? hostFromQuery : "";
+
+  const requestHeaders = await headers();
+  const headerHost =
+    requestHeaders.get("x-status-host") ||
+    requestHeaders.get("x-forwarded-host") ||
+    requestHeaders.get("host");
+
+  const hostname = normalizeHostname(hostnameFromQuery || headerHost);
+
+  return <PublicStatusOverview hostname={hostname} />;
 }

--- a/apps/client/app/api/tls/ask/route.ts
+++ b/apps/client/app/api/tls/ask/route.ts
@@ -1,0 +1,44 @@
+import { NextRequest, NextResponse } from "next/server";
+import { PrismaClient } from "@repo/store/generated/prisma";
+import { PrismaNeon } from "@prisma/adapter-neon";
+
+const adapter = new PrismaNeon({ connectionString: process.env.DATABASE_URL! });
+const prisma = new PrismaClient({ adapter });
+
+function normalizeHostname(rawHostname: string | null): string {
+  if (!rawHostname) return "";
+  return rawHostname.trim().toLowerCase().replace(/\.$/, "");
+}
+
+export async function GET(request: NextRequest) {
+  const requestedDomain = request.nextUrl.searchParams.get("domain");
+  const hostname = normalizeHostname(requestedDomain);
+
+  if (!hostname || !hostname.startsWith("status.")) {
+    return new NextResponse("forbidden", { status: 403 });
+  }
+
+  try {
+    const allowedDomain = await prisma.statusPageDomain.findFirst({
+      where: {
+        hostname,
+        verificationStatus: "VERIFIED",
+        statusPage: {
+          isPublished: true,
+        },
+      },
+      select: {
+        id: true,
+      },
+    });
+
+    if (!allowedDomain) {
+      return new NextResponse("forbidden", { status: 403 });
+    }
+
+    return new NextResponse("ok", { status: 200 });
+  } catch (error) {
+    console.error("[tls.ask] Failed to evaluate domain", { error, hostname });
+    return new NextResponse("error", { status: 500 });
+  }
+}

--- a/apps/client/app/components/status/PublicStatusOverview.tsx
+++ b/apps/client/app/components/status/PublicStatusOverview.tsx
@@ -1,0 +1,207 @@
+"use client";
+
+import Link from "next/link";
+import { AlertCircle, ExternalLink } from "lucide-react";
+import { trpc } from "@/lib/trpc";
+import { Tracker, type TrackerBlockProps } from "@/components/Tracker";
+
+interface PublicStatusOverviewProps {
+  hostname: string;
+}
+
+function getErrorMessage(error: { message: string }): string {
+  try {
+    const parsed = JSON.parse(error.message);
+    if (Array.isArray(parsed) && parsed.length > 0 && parsed[0].message) {
+      return parsed[0].message;
+    }
+  } catch {
+    // Keep original message when payload is not JSON.
+  }
+  return error.message;
+}
+
+function formatStatusTime(checkedAt: Date | string) {
+  const date = new Date(checkedAt);
+  return date.toLocaleString("en-US", {
+    month: "short",
+    day: "numeric",
+    hour: "2-digit",
+    minute: "2-digit",
+  });
+}
+
+function buildTrackerData(
+  statusPoints: Array<{
+    status: "UP" | "DOWN";
+    checkedAt: Date | string;
+    responseTimeMs: number | null;
+  }>,
+): TrackerBlockProps[] {
+  const SLOT_COUNT = 30;
+
+  const points = statusPoints.slice(0, SLOT_COUNT).reverse();
+  const pointBlocks: TrackerBlockProps[] = points.map((point, index) => {
+    const checkedAt = formatStatusTime(point.checkedAt);
+    const tooltipParts = [point.status, checkedAt];
+    if (point.responseTimeMs !== null) {
+      tooltipParts.push(`${point.responseTimeMs}ms`);
+    }
+
+    return {
+      key: `public-point-${index}-${point.checkedAt}`,
+      color: point.status === "UP" ? "bg-primary-action" : "bg-destructive",
+      tooltip: tooltipParts.join(" • "),
+      hoverEffect: true,
+    };
+  });
+
+  const emptyBlocksCount = SLOT_COUNT - pointBlocks.length;
+  const emptyBlocks = Array.from({ length: emptyBlocksCount }, (_, index) => ({
+    key: `public-empty-${index}`,
+    tooltip: "No check in this interval",
+    hoverEffect: false,
+  }));
+
+  return [...emptyBlocks, ...pointBlocks];
+}
+
+function renderStatusBadge(
+  currentStatus: {
+    status: "UP" | "DOWN";
+    checkedAt: Date | string;
+    responseTimeMs: number | null;
+  } | null,
+) {
+  if (!currentStatus) {
+    return (
+      <div className="rounded-full border border-border bg-muted px-3 py-1 text-sm text-muted-foreground">
+        Unknown
+      </div>
+    );
+  }
+
+  const label = currentStatus.status === "UP" ? "Up" : "Down";
+  const className =
+    currentStatus.status === "UP"
+      ? "border border-primary-action/30 bg-primary-action/10 text-primary-action"
+      : "border border-destructive/30 bg-destructive/10 text-destructive";
+
+  return (
+    <div
+      className={`rounded-full px-3 py-1 text-sm font-medium ${className}`}
+      title={`Last check: ${formatStatusTime(currentStatus.checkedAt)}`}
+    >
+      {label}
+    </div>
+  );
+}
+
+export function PublicStatusOverview({ hostname }: PublicStatusOverviewProps) {
+  const statusQuery = trpc.statusPage.publicByHost.useQuery(
+    {
+      hostname,
+      viewMode: "per-check",
+    },
+    {
+      enabled: Boolean(hostname),
+      retry: false,
+      refetchInterval: 60_000,
+      refetchOnWindowFocus: true,
+    },
+  );
+
+  if (!hostname) {
+    return (
+      <div className="mx-auto mt-24 max-w-3xl rounded-xl border border-border bg-card p-6 text-card-foreground">
+        Missing hostname. Open this page from your configured status subdomain.
+      </div>
+    );
+  }
+
+  return (
+    <div className="mx-auto w-full max-w-5xl px-4 pb-16 pt-20">
+      {statusQuery.isLoading ? (
+        <div className="rounded-xl border border-border bg-card p-6 text-card-foreground">
+          Loading public status page...
+        </div>
+      ) : statusQuery.isError ? (
+        <div className="rounded-xl border border-destructive/30 bg-destructive/5 p-6 text-destructive">
+          <div className="flex items-center gap-2 text-base font-medium">
+            <AlertCircle className="size-4" />
+            Unable to load status page
+          </div>
+          <p className="mt-2 text-sm">
+            {getErrorMessage(statusQuery.error) ||
+              "This status page is unavailable."}
+          </p>
+        </div>
+      ) : !statusQuery.data ? (
+        <div className="rounded-xl border border-border bg-card p-6 text-card-foreground">
+          Status page not found.
+        </div>
+      ) : (
+        <>
+          <div className="mb-8 rounded-2xl border border-border bg-card p-6 text-card-foreground">
+            <h1 className="text-3xl font-bold tracking-tight">
+              {statusQuery.data.statusPage.name}
+            </h1>
+            <p className="mt-2 text-sm text-muted-foreground">
+              Live status for <span className="font-medium">{hostname}</span>
+            </p>
+          </div>
+
+          <div className="space-y-6">
+            {statusQuery.data.statusPage.websites.length === 0 ? (
+              <div className="rounded-xl border border-border bg-card p-6 text-sm text-muted-foreground">
+                No monitors are currently attached to this status page.
+              </div>
+            ) : (
+              statusQuery.data.statusPage.websites.map((website) => (
+                <div
+                  key={website.websiteId}
+                  className="rounded-xl border border-border bg-card p-5 text-card-foreground"
+                >
+                  <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
+                    <div className="min-w-0 flex-1">
+                      <div className="truncate text-base font-semibold">
+                        {website.websiteName || website.websiteUrl}
+                      </div>
+                      <a
+                        href={website.websiteUrl}
+                        target="_blank"
+                        rel="noreferrer"
+                        className="mt-1 inline-flex items-center gap-1 text-sm text-muted-foreground underline underline-offset-4"
+                      >
+                        {website.websiteUrl}
+                        <ExternalLink className="size-3" />
+                      </a>
+                    </div>
+                    {renderStatusBadge(website.currentStatus)}
+                  </div>
+
+                  <div className="mt-4 space-y-1">
+                    <p className="text-xs text-muted-foreground">
+                      Last 30 checks
+                    </p>
+                    <Tracker
+                      data={buildTrackerData(website.statusPoints)}
+                      hoverEffect={website.statusPoints.length > 0}
+                    />
+                  </div>
+                </div>
+              ))
+            )}
+          </div>
+
+          <div className="mt-10 text-center text-sm text-muted-foreground">
+            Powered by{" "}
+            <Link href="/" className="underline underline-offset-4">
+              Uptique
+            </Link>
+          </div>
+        </>
+      )}
+    </div>
+  );
+}

--- a/apps/client/middleware.ts
+++ b/apps/client/middleware.ts
@@ -1,0 +1,69 @@
+import type { NextRequest } from "next/server";
+import { NextResponse } from "next/server";
+import {
+  API_HOST_PRODUCTION,
+  APP_HOST_PRODUCTION,
+  STATUS_PAGE_CNAME_TARGET,
+} from "@repo/config/constants";
+
+const EXCLUDED_PATH_PREFIXES = [
+  "/_next",
+  "/api",
+  "/favicon.ico",
+  "/robots.txt",
+];
+
+function normalizeHostname(rawHost: string | null): string | null {
+  if (!rawHost) return null;
+
+  const [firstHost] = rawHost.split(",");
+  const host = firstHost?.trim().toLowerCase();
+  if (!host) return null;
+
+  return host.split(":")[0] || null;
+}
+
+function isPlatformHost(hostname: string): boolean {
+  if (hostname === "localhost" || hostname === "127.0.0.1") {
+    return true;
+  }
+
+  return [APP_HOST_PRODUCTION, API_HOST_PRODUCTION, STATUS_PAGE_CNAME_TARGET]
+    .map((host) => host.toLowerCase())
+    .includes(hostname);
+}
+
+function isExcludedPath(pathname: string): boolean {
+  return EXCLUDED_PATH_PREFIXES.some((prefix) => pathname.startsWith(prefix));
+}
+
+export function middleware(request: NextRequest) {
+  if (isExcludedPath(request.nextUrl.pathname)) {
+    return NextResponse.next();
+  }
+
+  const hostname = normalizeHostname(
+    request.headers.get("x-forwarded-host") || request.headers.get("host"),
+  );
+
+  if (!hostname || isPlatformHost(hostname)) {
+    return NextResponse.next();
+  }
+
+  const rewrittenUrl = request.nextUrl.clone();
+  rewrittenUrl.pathname = "/status";
+  rewrittenUrl.searchParams.set("hostname", hostname);
+
+  const requestHeaders = new Headers(request.headers);
+  requestHeaders.set("x-status-host", hostname);
+
+  return NextResponse.rewrite(rewrittenUrl, {
+    request: {
+      headers: requestHeaders,
+    },
+  });
+}
+
+export const config = {
+  matcher: ["/((?!_next/static|_next/image).*)"],
+};

--- a/apps/client/next.config.ts
+++ b/apps/client/next.config.ts
@@ -7,6 +7,11 @@ dotenv.config({
   path: path.resolve(__dirname, "../../packages/config/.env"),
 });
 
+const backendProxyTarget =
+  process.env.INTERNAL_BACKEND_URL ||
+  process.env.NEXT_PUBLIC_API_PROXY_TARGET ||
+  "http://127.0.0.1:8084";
+
 const nextConfig: NextConfig = {
   // Allow user avatars (e.g. GitHub)
   images: {
@@ -27,6 +32,14 @@ const nextConfig: NextConfig = {
     CLIENT_ID_GITHUB: process.env.CLIENT_ID_GITHUB,
     CLIENT_SECRET_GITHUB: process.env.CLIENT_SECRET_GITHUB,
     NEXT_PUBLIC_GITHUB_CLIENT_ID: process.env.CLIENT_ID_GITHUB,
+  },
+  async rewrites() {
+    return [
+      {
+        source: "/trpc/:path*",
+        destination: `${backendProxyTarget}/:path*`,
+      },
+    ];
   },
   experimental: {
     mdxRs: true,

--- a/apps/server/src/index.ts
+++ b/apps/server/src/index.ts
@@ -1,8 +1,16 @@
-import { router, userRouter, websiteRouter } from "@repo/api";
+import {
+  router,
+  statusDomainRouter,
+  statusPageRouter,
+  userRouter,
+  websiteRouter,
+} from "@repo/api";
 
 const appRouter = router({
   user: userRouter,
   website: websiteRouter,
+  statusPage: statusPageRouter,
+  statusDomain: statusDomainRouter,
 });
 
 export type AppRouter = typeof appRouter;

--- a/docker/caddy/Caddyfile
+++ b/docker/caddy/Caddyfile
@@ -1,0 +1,44 @@
+{
+  email admin@raashed.xyz
+
+  # Restrict on-demand certificate issuance to verified status domains.
+  on_demand_tls {
+    ask http://127.0.0.1:3000/api/tls/ask
+    interval 2m
+    burst 10
+  }
+}
+
+uptique.raashed.xyz {
+  reverse_proxy 127.0.0.1:3000 {
+    header_up Host {host}
+    header_up X-Forwarded-Host {host}
+    header_up X-Forwarded-Proto {scheme}
+  }
+}
+
+uptique-server.raashed.xyz {
+  reverse_proxy 127.0.0.1:8084 {
+    header_up Host {host}
+    header_up X-Forwarded-Host {host}
+    header_up X-Forwarded-Proto {scheme}
+  }
+}
+
+# Catch-all HTTPS entrypoint for verified customer status domains.
+:443 {
+  tls {
+    on_demand
+  }
+
+  reverse_proxy 127.0.0.1:3000 {
+    header_up Host {host}
+    header_up X-Forwarded-Host {host}
+    header_up X-Forwarded-Proto {scheme}
+  }
+}
+
+# Redirect plain HTTP to HTTPS.
+:80 {
+  redir https://{host}{uri} permanent
+}

--- a/docker/caddy/README.md
+++ b/docker/caddy/README.md
@@ -1,0 +1,58 @@
+# Caddy Ingress for Custom Status Domains
+
+This setup enables customer-facing status pages on custom hostnames like:
+
+- `status.startup.com`
+
+It uses Caddy on-demand TLS with an allowlist check against the app's verified
+domain records.
+
+## Prerequisites
+
+- Frontend app reachable at `127.0.0.1:3000`
+- API server reachable at `127.0.0.1:8084`
+- DNS for customer hostnames points to this server
+- Customer hostnames are verified in-app with both:
+  - `CNAME status.customer.com -> status.raashed.xyz`
+  - TXT verification record generated in dashboard
+
+## Files
+
+- Caddy config: `docker/caddy/Caddyfile`
+- TLS ask endpoint: `apps/client/app/api/tls/ask/route.ts`
+
+## How TLS issuance is restricted
+
+1. Caddy receives a request for a new hostname.
+2. Caddy calls `GET /api/tls/ask?domain=<hostname>`.
+3. The app only returns `200` if:
+   - hostname exists in `StatusPageDomain`,
+   - verification status is `VERIFIED`,
+   - linked status page is published.
+4. Caddy issues certificate only when the ask endpoint allows it.
+
+## Install Caddy (Ubuntu)
+
+```bash
+sudo apt update
+sudo apt install -y debian-keyring debian-archive-keyring apt-transport-https curl
+curl -1sLf 'https://dl.cloudsmith.io/public/caddy/stable/gpg.key' | sudo gpg --dearmor -o /usr/share/keyrings/caddy-stable-archive-keyring.gpg
+curl -1sLf 'https://dl.cloudsmith.io/public/caddy/stable/debian.deb.txt' | sudo tee /etc/apt/sources.list.d/caddy-stable.list
+sudo apt update
+sudo apt install -y caddy
+```
+
+## Deploy Caddyfile
+
+```bash
+sudo cp docker/caddy/Caddyfile /etc/caddy/Caddyfile
+sudo caddy validate --config /etc/caddy/Caddyfile
+sudo systemctl restart caddy
+sudo systemctl status caddy
+```
+
+## Operational notes
+
+- Keep Caddy `ask` endpoint reachable from the Caddy host.
+- Monitor Let's Encrypt issuance rate and Caddy logs.
+- Keep DNS verification flow enforced in dashboard before marking domains active.

--- a/packages/api/src/__tests__/routes/status-domain.test.ts
+++ b/packages/api/src/__tests__/routes/status-domain.test.ts
@@ -1,0 +1,146 @@
+import { describe, it, expect } from "bun:test";
+import { TRPCError } from "@trpc/server";
+import { prismaClient } from "@repo/store";
+import { Prisma } from "@repo/store/generated/prisma";
+import {
+  createAuthenticatedCaller,
+  createTestCaller,
+  createTestStatusDomain,
+  createTestStatusPage,
+  createTestUser,
+  createTestWebsite,
+} from "../helpers.js";
+
+async function hasStatusSchema(): Promise<boolean> {
+  try {
+    await prismaClient.statusPage.count();
+    return true;
+  } catch (error) {
+    if (
+      error instanceof Prisma.PrismaClientKnownRequestError &&
+      error.code === "P2021"
+    ) {
+      return false;
+    }
+    throw error;
+  }
+}
+
+describe("Status Domain Routes", () => {
+  describe("requestVerification", () => {
+    it("creates DNS verification instructions for a status page", async () => {
+      if (!(await hasStatusSchema())) return;
+      const user = await createTestUser();
+      const website = await createTestWebsite(user.id);
+      const statusPage = await createTestStatusPage(user.id, [website.id], {
+        slug: `status-${Date.now()}`,
+      });
+      const hostname = `status.test${Date.now()}.example.com`;
+
+      const caller = createAuthenticatedCaller(user.id);
+      const result = await caller.statusDomain.requestVerification({
+        statusPageId: statusPage.id,
+        hostname,
+      });
+
+      expect(result.hostname).toBe(hostname);
+      expect(result.verificationStatus).toBe("PENDING");
+      expect(result.cnameRecordName).toBe(hostname);
+      expect(result.txtRecordName).toContain(hostname);
+
+      const persisted = await prismaClient.statusPageDomain.findUnique({
+        where: { statusPageId: statusPage.id },
+      });
+      expect(persisted).not.toBeNull();
+      expect(persisted?.hostname).toBe(hostname);
+    });
+
+    it("rejects requesting verification on another user's status page", async () => {
+      if (!(await hasStatusSchema())) return;
+      const owner = await createTestUser();
+      const intruder = await createTestUser();
+      const website = await createTestWebsite(owner.id);
+      const statusPage = await createTestStatusPage(owner.id, [website.id], {
+        slug: `owner-${Date.now()}`,
+      });
+
+      const caller = createAuthenticatedCaller(intruder.id);
+      await expect(
+        caller.statusDomain.requestVerification({
+          statusPageId: statusPage.id,
+          hostname: `status.test${Date.now()}.example.com`,
+        }),
+      ).rejects.toThrow(TRPCError);
+    });
+  });
+
+  describe("verify", () => {
+    it("marks domain as FAILED when DNS records do not match", async () => {
+      if (!(await hasStatusSchema())) return;
+      const user = await createTestUser();
+      const website = await createTestWebsite(user.id);
+      const statusPage = await createTestStatusPage(user.id, [website.id], {
+        slug: `verify-${Date.now()}`,
+      });
+
+      const hostname = `status.test${Date.now()}.example.invalid`;
+      const caller = createAuthenticatedCaller(user.id);
+
+      await caller.statusDomain.requestVerification({
+        statusPageId: statusPage.id,
+        hostname,
+      });
+
+      const result = await caller.statusDomain.verify({
+        statusPageId: statusPage.id,
+        hostname,
+      });
+
+      expect(result.verificationStatus).toBe("FAILED");
+      expect(result.txtVerified).toBe(false);
+      expect(result.cnameVerified).toBe(false);
+    });
+  });
+
+  describe("canIssueTls", () => {
+    it("returns false for unverified domains", async () => {
+      if (!(await hasStatusSchema())) return;
+      const user = await createTestUser();
+      const website = await createTestWebsite(user.id);
+      const statusPage = await createTestStatusPage(user.id, [website.id], {
+        slug: `tls-pending-${Date.now()}`,
+      });
+      const hostname = `status.test${Date.now()}.example.com`;
+
+      await createTestStatusDomain(statusPage.id, {
+        hostname,
+        verificationStatus: "PENDING",
+      });
+
+      const caller = createTestCaller();
+      const result = await caller.statusDomain.canIssueTls({ hostname });
+      expect(result.allowed).toBe(false);
+    });
+
+    it("returns true for verified published domains", async () => {
+      if (!(await hasStatusSchema())) return;
+      const user = await createTestUser();
+      const website = await createTestWebsite(user.id);
+      const statusPage = await createTestStatusPage(user.id, [website.id], {
+        slug: `tls-verified-${Date.now()}`,
+        isPublished: true,
+      });
+      const hostname = `status.test${Date.now()}.example.com`;
+
+      await createTestStatusDomain(statusPage.id, {
+        hostname,
+        verificationStatus: "VERIFIED",
+        verifiedAt: new Date(),
+      });
+
+      const caller = createTestCaller();
+      const result = await caller.statusDomain.canIssueTls({ hostname });
+      expect(result.allowed).toBe(true);
+    });
+  });
+});

--- a/packages/api/src/__tests__/routes/status-page.test.ts
+++ b/packages/api/src/__tests__/routes/status-page.test.ts
@@ -1,0 +1,154 @@
+import { describe, it, expect } from "bun:test";
+import { TRPCError } from "@trpc/server";
+import { prismaClient } from "@repo/store";
+import { Prisma } from "@repo/store/generated/prisma";
+import {
+  createAuthenticatedCaller,
+  createTestCaller,
+  createTestStatusDomain,
+  createTestStatusPage,
+  createTestUser,
+  createTestWebsite,
+} from "../helpers.js";
+
+async function hasStatusSchema(): Promise<boolean> {
+  try {
+    await prismaClient.statusPage.count();
+    return true;
+  } catch (error) {
+    if (
+      error instanceof Prisma.PrismaClientKnownRequestError &&
+      error.code === "P2021"
+    ) {
+      return false;
+    }
+    throw error;
+  }
+}
+
+describe("Status Page Routes", () => {
+  describe("create", () => {
+    it("creates a status page with monitor mappings", async () => {
+      if (!(await hasStatusSchema())) return;
+      const user = await createTestUser();
+      const website1 = await createTestWebsite(user.id, {
+        url: "https://one.example.com",
+      });
+      const website2 = await createTestWebsite(user.id, {
+        url: "https://two.example.com",
+      });
+
+      const caller = createAuthenticatedCaller(user.id);
+      const result = await caller.statusPage.create({
+        name: "Acme Status",
+        slug: `acme-${Date.now()}`,
+        monitorIds: [website1.id, website2.id],
+      });
+
+      expect(result.name).toBe("Acme Status");
+      expect(result.monitorCount).toBe(2);
+      expect(result.domain).toBeNull();
+
+      const monitorCount = await prismaClient.statusPageMonitor.count({
+        where: { statusPageId: result.id },
+      });
+      expect(monitorCount).toBe(2);
+    });
+
+    it("rejects monitor IDs that do not belong to user", async () => {
+      if (!(await hasStatusSchema())) return;
+      const user1 = await createTestUser();
+      const user2 = await createTestUser();
+      const website = await createTestWebsite(user2.id);
+
+      const caller = createAuthenticatedCaller(user1.id);
+
+      await expect(
+        caller.statusPage.create({
+          name: "Invalid monitors",
+          slug: `invalid-${Date.now()}`,
+          monitorIds: [website.id],
+        }),
+      ).rejects.toThrow(TRPCError);
+    });
+  });
+
+  describe("list", () => {
+    it("returns only status pages owned by authenticated user", async () => {
+      if (!(await hasStatusSchema())) return;
+      const user1 = await createTestUser();
+      const user2 = await createTestUser();
+      const website1 = await createTestWebsite(user1.id);
+      const website2 = await createTestWebsite(user2.id);
+
+      await createTestStatusPage(user1.id, [website1.id], {
+        slug: `u1-${Date.now()}`,
+      });
+      await createTestStatusPage(user2.id, [website2.id], {
+        slug: `u2-${Date.now()}`,
+      });
+
+      const caller = createAuthenticatedCaller(user1.id);
+      const result = await caller.statusPage.list();
+
+      expect(result.statusPages).toHaveLength(1);
+      expect(result.statusPages[0]?.userId).toBe(user1.id);
+    });
+  });
+
+  describe("publicByHost", () => {
+    it("returns public status page by verified hostname", async () => {
+      if (!(await hasStatusSchema())) return;
+      const user = await createTestUser();
+      const website = await createTestWebsite(user.id, {
+        url: "https://public.example.com",
+      });
+      const statusPage = await createTestStatusPage(user.id, [website.id], {
+        name: "Public Status",
+        slug: `public-${Date.now()}`,
+        isPublished: true,
+      });
+      const hostname = `status.test${Date.now()}.example.com`;
+      await createTestStatusDomain(statusPage.id, {
+        hostname,
+        verificationStatus: "VERIFIED",
+        verifiedAt: new Date(),
+      });
+
+      const caller = createTestCaller();
+      const result = await caller.statusPage.publicByHost({
+        hostname,
+        viewMode: "per-check",
+      });
+
+      expect(result.statusPage.hostname).toBe(hostname);
+      expect(result.statusPage.name).toBe("Public Status");
+      expect(result.statusPage.websites).toHaveLength(1);
+      expect(result.statusPage.websites[0]?.websiteUrl).toBe(
+        "https://public.example.com",
+      );
+    });
+
+    it("does not return unverified domains", async () => {
+      if (!(await hasStatusSchema())) return;
+      const user = await createTestUser();
+      const website = await createTestWebsite(user.id);
+      const statusPage = await createTestStatusPage(user.id, [website.id], {
+        slug: `private-${Date.now()}`,
+      });
+      const hostname = `status.test${Date.now()}.example.com`;
+      await createTestStatusDomain(statusPage.id, {
+        hostname,
+        verificationStatus: "PENDING",
+      });
+
+      const caller = createTestCaller();
+      await expect(
+        caller.statusPage.publicByHost({
+          hostname,
+          viewMode: "per-check",
+        }),
+      ).rejects.toThrow(TRPCError);
+    });
+  });
+});

--- a/packages/api/src/__tests__/setup.ts
+++ b/packages/api/src/__tests__/setup.ts
@@ -1,5 +1,20 @@
 import { beforeAll, afterAll, afterEach } from "bun:test";
 import { prismaClient } from "@repo/store";
+import { Prisma } from "@repo/store/generated/prisma";
+
+async function safeDeleteMany(deleteOperation: () => Promise<unknown>) {
+  try {
+    await deleteOperation();
+  } catch (error) {
+    if (
+      error instanceof Prisma.PrismaClientKnownRequestError &&
+      error.code === "P2021"
+    ) {
+      return;
+    }
+    throw error;
+  }
+}
 
 // Clean up database before tests run
 beforeAll(async () => {
@@ -15,10 +30,13 @@ beforeAll(async () => {
 // Clean up data after each test
 afterEach(async () => {
   // Delete in order to respect foreign key constraints
-  await prismaClient.emailVerificationToken.deleteMany();
-  await prismaClient.website.deleteMany();
-  await prismaClient.account.deleteMany();
-  await prismaClient.user.deleteMany();
+  await safeDeleteMany(() => prismaClient.statusPageDomain.deleteMany());
+  await safeDeleteMany(() => prismaClient.statusPageMonitor.deleteMany());
+  await safeDeleteMany(() => prismaClient.statusPage.deleteMany());
+  await safeDeleteMany(() => prismaClient.emailVerificationToken.deleteMany());
+  await safeDeleteMany(() => prismaClient.website.deleteMany());
+  await safeDeleteMany(() => prismaClient.account.deleteMany());
+  await safeDeleteMany(() => prismaClient.user.deleteMany());
 });
 
 // Disconnect after all tests

--- a/packages/api/src/index.ts
+++ b/packages/api/src/index.ts
@@ -10,6 +10,8 @@ export type { Context } from "./trpc.js";
 // Export routers
 export { userRouter } from "./routes/user.js";
 export { websiteRouter } from "./routes/website.js";
+export { statusPageRouter } from "./routes/status-page.js";
+export { statusDomainRouter } from "./routes/status-domain.js";
 
 // Export type utilities
 export type { inferRouterInputs, inferRouterOutputs } from "@trpc/server";

--- a/packages/api/src/routes/status-domain.ts
+++ b/packages/api/src/routes/status-domain.ts
@@ -1,0 +1,227 @@
+import { resolveCname, resolveTxt } from "node:dns/promises";
+import { TRPCError } from "@trpc/server";
+import { prismaClient } from "@repo/store";
+import {
+  canIssueTlsInput,
+  canIssueTlsOutput,
+  requestStatusDomainVerificationInput,
+  requestStatusDomainVerificationOutput,
+  verifyStatusDomainInput,
+  verifyStatusDomainOutput,
+} from "@repo/validators";
+import {
+  STATUS_PAGE_CNAME_TARGET,
+  STATUS_PAGE_VERIFY_TXT_PREFIX,
+} from "@repo/config/constants";
+import { publicProcedure, protectedProcedure, router } from "../trpc.js";
+
+function normalizeDnsValue(value: string): string {
+  return value.trim().toLowerCase().replace(/\.$/, "");
+}
+
+function getDnsRecords(hostname: string, verificationToken: string) {
+  return {
+    cnameRecordName: hostname,
+    cnameRecordValue: STATUS_PAGE_CNAME_TARGET,
+    txtRecordName: `${STATUS_PAGE_VERIFY_TXT_PREFIX}.${hostname}`,
+    txtRecordValue: verificationToken,
+  };
+}
+
+async function resolveTxtValues(hostname: string): Promise<string[]> {
+  try {
+    const records = await resolveTxt(hostname);
+    return records.flat().map((value) => value.trim());
+  } catch (error) {
+    // DNS propagation and missing records should be treated as non-fatal.
+    if (
+      error &&
+      typeof error === "object" &&
+      "code" in error &&
+      (error.code === "ENODATA" ||
+        error.code === "ENOTFOUND" ||
+        error.code === "EAI_AGAIN" ||
+        error.code === "SERVFAIL")
+    ) {
+      return [];
+    }
+    throw error;
+  }
+}
+
+async function resolveCnameValues(hostname: string): Promise<string[]> {
+  try {
+    const records = await resolveCname(hostname);
+    return records.map((value) => normalizeDnsValue(value));
+  } catch (error) {
+    if (
+      error &&
+      typeof error === "object" &&
+      "code" in error &&
+      (error.code === "ENODATA" ||
+        error.code === "ENOTFOUND" ||
+        error.code === "EAI_AGAIN" ||
+        error.code === "SERVFAIL")
+    ) {
+      return [];
+    }
+    throw error;
+  }
+}
+
+function createVerificationToken(): string {
+  return `uptique-${crypto.randomUUID().replace(/-/g, "")}`;
+}
+
+export const statusDomainRouter = router({
+  requestVerification: protectedProcedure
+    .input(requestStatusDomainVerificationInput)
+    .output(requestStatusDomainVerificationOutput)
+    .mutation(async ({ ctx, input }) => {
+      const userId = ctx.user.userId;
+      const { statusPageId, hostname } = input;
+
+      const statusPage = await prismaClient.statusPage.findFirst({
+        where: {
+          id: statusPageId,
+          userId,
+        },
+      });
+
+      if (!statusPage) {
+        throw new TRPCError({
+          code: "NOT_FOUND",
+          message: "Status page not found",
+        });
+      }
+
+      const existingHostname = await prismaClient.statusPageDomain.findUnique({
+        where: {
+          hostname,
+        },
+      });
+
+      if (existingHostname && existingHostname.statusPageId !== statusPageId) {
+        throw new TRPCError({
+          code: "CONFLICT",
+          message: "Hostname is already claimed by another status page",
+        });
+      }
+
+      const verificationToken = createVerificationToken();
+
+      const domain = await prismaClient.statusPageDomain.upsert({
+        where: {
+          statusPageId,
+        },
+        update: {
+          hostname,
+          verificationToken,
+          verificationStatus: "PENDING",
+          verifiedAt: null,
+        },
+        create: {
+          statusPageId,
+          hostname,
+          verificationToken,
+          verificationStatus: "PENDING",
+        },
+      });
+
+      return {
+        statusPageId: domain.statusPageId,
+        hostname: domain.hostname,
+        verificationStatus: domain.verificationStatus,
+        ...getDnsRecords(domain.hostname, domain.verificationToken),
+      };
+    }),
+
+  verify: protectedProcedure
+    .input(verifyStatusDomainInput)
+    .output(verifyStatusDomainOutput)
+    .mutation(async ({ ctx, input }) => {
+      const userId = ctx.user.userId;
+      const { statusPageId, hostname } = input;
+
+      const domain = await prismaClient.statusPageDomain.findFirst({
+        where: {
+          statusPageId,
+          hostname,
+          statusPage: {
+            userId,
+          },
+        },
+        include: {
+          statusPage: {
+            select: {
+              userId: true,
+            },
+          },
+        },
+      });
+
+      if (!domain) {
+        throw new TRPCError({
+          code: "NOT_FOUND",
+          message: "Domain mapping not found",
+        });
+      }
+
+      const dnsRecords = getDnsRecords(
+        domain.hostname,
+        domain.verificationToken,
+      );
+      const [txtValues, cnameValues] = await Promise.all([
+        resolveTxtValues(dnsRecords.txtRecordName),
+        resolveCnameValues(dnsRecords.cnameRecordName),
+      ]);
+
+      const txtVerified = txtValues.includes(dnsRecords.txtRecordValue);
+      const cnameVerified = cnameValues.includes(
+        normalizeDnsValue(dnsRecords.cnameRecordValue),
+      );
+      const verificationPassed = txtVerified && cnameVerified;
+
+      const updatedDomain = await prismaClient.statusPageDomain.update({
+        where: {
+          id: domain.id,
+        },
+        data: {
+          verificationStatus: verificationPassed ? "VERIFIED" : "FAILED",
+          verifiedAt: verificationPassed ? new Date() : null,
+        },
+      });
+
+      return {
+        statusPageId: updatedDomain.statusPageId,
+        hostname: updatedDomain.hostname,
+        verificationStatus: updatedDomain.verificationStatus,
+        txtVerified,
+        cnameVerified,
+        verifiedAt: updatedDomain.verifiedAt,
+        ...dnsRecords,
+      };
+    }),
+
+  canIssueTls: publicProcedure
+    .input(canIssueTlsInput)
+    .output(canIssueTlsOutput)
+    .query(async ({ input }) => {
+      const domain = await prismaClient.statusPageDomain.findFirst({
+        where: {
+          hostname: input.hostname,
+          verificationStatus: "VERIFIED",
+          statusPage: {
+            isPublished: true,
+          },
+        },
+        select: {
+          id: true,
+        },
+      });
+
+      return {
+        allowed: Boolean(domain),
+      };
+    }),
+});

--- a/packages/api/src/routes/status-page.ts
+++ b/packages/api/src/routes/status-page.ts
@@ -1,0 +1,404 @@
+import { TRPCError } from "@trpc/server";
+import { prismaClient } from "@repo/store";
+import {
+  createStatusPageInput,
+  publicStatusPageByHostInput,
+  statusPageListOutput,
+  statusPageOutput,
+  statusPagePublicOutput,
+  updateStatusPageInput,
+} from "@repo/validators";
+import {
+  getRecentStatusEvents,
+  getStatusEventsForLookbackHours,
+} from "@repo/clickhouse";
+import { publicProcedure, protectedProcedure, router } from "../trpc.js";
+
+const STATUS_EVENT_QUERY_CONFIG = {
+  PER_CHECK_LIMIT: 90,
+  PER_DAY_LOOKBACK_DAYS: 31,
+} as const;
+
+type WebsiteStatusEvent = {
+  website_id: string;
+  region_id: string;
+  status: "UP" | "DOWN";
+  checked_at: string;
+  response_time_ms: number | null;
+  http_status_code: number | null;
+};
+
+type WebsiteStatusSummary = {
+  websiteId: string;
+  websiteName: string | null;
+  websiteUrl: string;
+  statusPoints: Array<{
+    status: "UP" | "DOWN";
+    checkedAt: Date;
+    responseTimeMs: number | null;
+    httpStatusCode: number | null;
+  }>;
+  currentStatus: {
+    status: "UP" | "DOWN";
+    checkedAt: Date;
+    responseTimeMs: number | null;
+    httpStatusCode: number | null;
+    regionId: string;
+  } | null;
+};
+
+async function getStatusEventsByWebsiteIds(
+  websiteIds: string[],
+  viewMode: "per-check" | "per-day",
+): Promise<WebsiteStatusEvent[]> {
+  if (websiteIds.length === 0) {
+    return [];
+  }
+
+  try {
+    if (viewMode === "per-day") {
+      return await getStatusEventsForLookbackHours(
+        websiteIds,
+        STATUS_EVENT_QUERY_CONFIG.PER_DAY_LOOKBACK_DAYS * 24,
+      );
+    }
+    return await getRecentStatusEvents(
+      websiteIds,
+      STATUS_EVENT_QUERY_CONFIG.PER_CHECK_LIMIT,
+    );
+  } catch (error) {
+    console.error(
+      "[statusPage] Failed to fetch status events from ClickHouse",
+      {
+        error,
+      },
+    );
+    return [];
+  }
+}
+
+function mapWebsiteStatuses(
+  websites: Array<{
+    id: string;
+    name: string | null;
+    url: string;
+  }>,
+  statusEvents: WebsiteStatusEvent[],
+): WebsiteStatusSummary[] {
+  const statusByWebsite = new Map<
+    string,
+    {
+      statusPoints: WebsiteStatusSummary[number]["statusPoints"];
+      currentStatus: WebsiteStatusSummary[number]["currentStatus"];
+    }
+  >();
+
+  for (const event of statusEvents) {
+    if (!statusByWebsite.has(event.website_id)) {
+      statusByWebsite.set(event.website_id, {
+        statusPoints: [],
+        currentStatus: {
+          status: event.status,
+          checkedAt: new Date(event.checked_at),
+          responseTimeMs: event.response_time_ms,
+          httpStatusCode: event.http_status_code,
+          regionId: event.region_id,
+        },
+      });
+    }
+
+    statusByWebsite.get(event.website_id)!.statusPoints.push({
+      status: event.status,
+      checkedAt: new Date(event.checked_at),
+      responseTimeMs: event.response_time_ms,
+      httpStatusCode: event.http_status_code,
+    });
+  }
+
+  return websites.map((website) => {
+    const statusData = statusByWebsite.get(website.id);
+    return {
+      websiteId: website.id,
+      websiteName: website.name,
+      websiteUrl: website.url,
+      statusPoints: statusData?.statusPoints || [],
+      currentStatus: statusData?.currentStatus || null,
+    };
+  });
+}
+
+function toStatusPageOutput(statusPage: {
+  id: string;
+  name: string;
+  slug: string;
+  isPublished: boolean;
+  userId: string;
+  createdAt: Date;
+  updatedAt: Date;
+  monitors: Array<{ websiteId: string }>;
+  domain: {
+    id: string;
+    hostname: string;
+    verificationStatus: "PENDING" | "VERIFIED" | "FAILED";
+    verifiedAt: Date | null;
+    createdAt: Date;
+    updatedAt: Date;
+  } | null;
+}) {
+  return {
+    id: statusPage.id,
+    name: statusPage.name,
+    slug: statusPage.slug,
+    isPublished: statusPage.isPublished,
+    userId: statusPage.userId,
+    monitorCount: statusPage.monitors.length,
+    domain: statusPage.domain,
+    createdAt: statusPage.createdAt,
+    updatedAt: statusPage.updatedAt,
+  };
+}
+
+export const statusPageRouter = router({
+  create: protectedProcedure
+    .input(createStatusPageInput)
+    .output(statusPageOutput)
+    .mutation(async ({ ctx, input }) => {
+      const userId = ctx.user.userId;
+      const { name, slug, monitorIds, isPublished } = input;
+
+      const websites = await prismaClient.website.findMany({
+        where: {
+          id: {
+            in: monitorIds,
+          },
+          userId,
+          isActive: true,
+        },
+        select: {
+          id: true,
+        },
+      });
+
+      if (websites.length !== monitorIds.length) {
+        throw new TRPCError({
+          code: "BAD_REQUEST",
+          message: "One or more selected monitors are invalid",
+        });
+      }
+
+      try {
+        const statusPage = await prismaClient.statusPage.create({
+          data: {
+            name,
+            slug,
+            userId,
+            isPublished: isPublished ?? true,
+            monitors: {
+              createMany: {
+                data: monitorIds.map((websiteId) => ({
+                  websiteId,
+                })),
+              },
+            },
+          },
+          include: {
+            monitors: {
+              select: { websiteId: true },
+            },
+            domain: true,
+          },
+        });
+
+        return toStatusPageOutput(statusPage);
+      } catch (error) {
+        if (
+          error &&
+          typeof error === "object" &&
+          "code" in error &&
+          error.code === "P2002"
+        ) {
+          throw new TRPCError({
+            code: "CONFLICT",
+            message: "Slug already exists",
+          });
+        }
+        throw error;
+      }
+    }),
+
+  update: protectedProcedure
+    .input(updateStatusPageInput)
+    .output(statusPageOutput)
+    .mutation(async ({ ctx, input }) => {
+      const userId = ctx.user.userId;
+      const { id, monitorIds, ...updates } = input;
+
+      const existingStatusPage = await prismaClient.statusPage.findFirst({
+        where: {
+          id,
+          userId,
+        },
+        include: {
+          monitors: { select: { websiteId: true } },
+          domain: true,
+        },
+      });
+
+      if (!existingStatusPage) {
+        throw new TRPCError({
+          code: "NOT_FOUND",
+          message: "Status page not found",
+        });
+      }
+
+      if (monitorIds) {
+        const websites = await prismaClient.website.findMany({
+          where: {
+            id: { in: monitorIds },
+            userId,
+            isActive: true,
+          },
+          select: {
+            id: true,
+          },
+        });
+
+        if (websites.length !== monitorIds.length) {
+          throw new TRPCError({
+            code: "BAD_REQUEST",
+            message: "One or more selected monitors are invalid",
+          });
+        }
+      }
+
+      try {
+        const updated = await prismaClient.$transaction(async (tx) => {
+          const updatedStatusPage = await tx.statusPage.update({
+            where: { id },
+            data: updates,
+          });
+
+          if (monitorIds) {
+            await tx.statusPageMonitor.deleteMany({
+              where: { statusPageId: id },
+            });
+            await tx.statusPageMonitor.createMany({
+              data: monitorIds.map((websiteId) => ({
+                statusPageId: id,
+                websiteId,
+              })),
+            });
+          }
+
+          return tx.statusPage.findUniqueOrThrow({
+            where: { id: updatedStatusPage.id },
+            include: {
+              monitors: { select: { websiteId: true } },
+              domain: true,
+            },
+          });
+        });
+
+        return toStatusPageOutput(updated);
+      } catch (error) {
+        if (
+          error &&
+          typeof error === "object" &&
+          "code" in error &&
+          error.code === "P2002"
+        ) {
+          throw new TRPCError({
+            code: "CONFLICT",
+            message: "Slug already exists",
+          });
+        }
+        throw error;
+      }
+    }),
+
+  list: protectedProcedure
+    .output(statusPageListOutput)
+    .query(async ({ ctx }) => {
+      const statusPages = await prismaClient.statusPage.findMany({
+        where: {
+          userId: ctx.user.userId,
+        },
+        include: {
+          monitors: {
+            select: { websiteId: true },
+          },
+          domain: true,
+        },
+        orderBy: {
+          createdAt: "desc",
+        },
+      });
+
+      return {
+        statusPages: statusPages.map(toStatusPageOutput),
+      };
+    }),
+
+  publicByHost: publicProcedure
+    .input(publicStatusPageByHostInput)
+    .output(statusPagePublicOutput)
+    .query(async ({ input }) => {
+      const { hostname, viewMode } = input;
+
+      const domain = await prismaClient.statusPageDomain.findFirst({
+        where: {
+          hostname,
+          verificationStatus: "VERIFIED",
+          statusPage: {
+            isPublished: true,
+          },
+        },
+        include: {
+          statusPage: {
+            include: {
+              monitors: {
+                include: {
+                  website: true,
+                },
+              },
+            },
+          },
+        },
+      });
+
+      if (!domain) {
+        throw new TRPCError({
+          code: "NOT_FOUND",
+          message: "Status page not found for this hostname",
+        });
+      }
+
+      const activeWebsites = domain.statusPage.monitors
+        .map((monitor) => monitor.website)
+        .filter((website) => website.isActive);
+
+      const websiteIds = activeWebsites.map((website) => website.id);
+      const statusEvents = await getStatusEventsByWebsiteIds(
+        websiteIds,
+        viewMode,
+      );
+      const websites = mapWebsiteStatuses(
+        activeWebsites.map((website) => ({
+          id: website.id,
+          name: website.name,
+          url: website.url,
+        })),
+        statusEvents,
+      );
+
+      return {
+        statusPage: {
+          id: domain.statusPage.id,
+          name: domain.statusPage.name,
+          slug: domain.statusPage.slug,
+          hostname: domain.hostname,
+          websites,
+        },
+      };
+    }),
+});

--- a/packages/config/src/constants.ts
+++ b/packages/config/src/constants.ts
@@ -16,6 +16,18 @@ export const FRONTEND_URL =
     ? FRONTEND_URL_PRODUCTION
     : FRONTEND_URL_DEVELOPMENT;
 
+export const APP_HOST_PRODUCTION = "uptique.raashed.xyz";
+export const API_HOST_PRODUCTION = "uptique-server.raashed.xyz";
+export const STATUS_PAGE_CNAME_TARGET_PRODUCTION = "status.raashed.xyz";
+export const STATUS_PAGE_CNAME_TARGET_DEVELOPMENT = "localhost";
+export const STATUS_PAGE_CNAME_TARGET =
+  process.env.STATUS_PAGE_CNAME_TARGET ||
+  (process.env.NODE_ENV === "production"
+    ? STATUS_PAGE_CNAME_TARGET_PRODUCTION
+    : STATUS_PAGE_CNAME_TARGET_DEVELOPMENT);
+export const STATUS_PAGE_VERIFY_TXT_PREFIX =
+  process.env.STATUS_PAGE_VERIFY_TXT_PREFIX || "_uptique-verify";
+
 // CORS allowed origins for the backend
 export const CORS_ALLOWED_ORIGINS = [
   FRONTEND_URL_DEVELOPMENT,

--- a/packages/store/prisma/migrations/20260215120000_add_status_pages_and_domains/migration.sql
+++ b/packages/store/prisma/migrations/20260215120000_add_status_pages_and_domains/migration.sql
@@ -1,0 +1,68 @@
+-- Create enum for status page custom domain verification
+CREATE TYPE "StatusDomainVerificationStatus" AS ENUM ('PENDING', 'VERIFIED', 'FAILED');
+
+-- CreateTable
+CREATE TABLE "StatusPage" (
+    "id" TEXT NOT NULL,
+    "name" TEXT NOT NULL,
+    "slug" TEXT NOT NULL,
+    "isPublished" BOOLEAN NOT NULL DEFAULT true,
+    "userId" TEXT NOT NULL,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "StatusPage_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "StatusPageMonitor" (
+    "statusPageId" TEXT NOT NULL,
+    "websiteId" TEXT NOT NULL,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "StatusPageMonitor_pkey" PRIMARY KEY ("statusPageId","websiteId")
+);
+
+-- CreateTable
+CREATE TABLE "StatusPageDomain" (
+    "id" TEXT NOT NULL,
+    "statusPageId" TEXT NOT NULL,
+    "hostname" TEXT NOT NULL,
+    "verificationToken" TEXT NOT NULL,
+    "verificationStatus" "StatusDomainVerificationStatus" NOT NULL DEFAULT 'PENDING',
+    "verifiedAt" TIMESTAMP(3),
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "StatusPageDomain_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE UNIQUE INDEX "StatusPage_slug_key" ON "StatusPage"("slug");
+
+-- CreateIndex
+CREATE INDEX "StatusPage_userId_idx" ON "StatusPage"("userId");
+
+-- CreateIndex
+CREATE INDEX "StatusPageMonitor_websiteId_idx" ON "StatusPageMonitor"("websiteId");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "StatusPageDomain_statusPageId_key" ON "StatusPageDomain"("statusPageId");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "StatusPageDomain_hostname_key" ON "StatusPageDomain"("hostname");
+
+-- CreateIndex
+CREATE INDEX "StatusPageDomain_verificationStatus_idx" ON "StatusPageDomain"("verificationStatus");
+
+-- AddForeignKey
+ALTER TABLE "StatusPage" ADD CONSTRAINT "StatusPage_userId_fkey" FOREIGN KEY ("userId") REFERENCES "User"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "StatusPageMonitor" ADD CONSTRAINT "StatusPageMonitor_statusPageId_fkey" FOREIGN KEY ("statusPageId") REFERENCES "StatusPage"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "StatusPageMonitor" ADD CONSTRAINT "StatusPageMonitor_websiteId_fkey" FOREIGN KEY ("websiteId") REFERENCES "Website"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "StatusPageDomain" ADD CONSTRAINT "StatusPageDomain_statusPageId_fkey" FOREIGN KEY ("statusPageId") REFERENCES "StatusPage"("id") ON DELETE CASCADE ON UPDATE CASCADE;

--- a/packages/store/prisma/schema.prisma
+++ b/packages/store/prisma/schema.prisma
@@ -12,18 +12,25 @@ enum UptimeStatus {
   DOWN
 }
 
+enum StatusDomainVerificationStatus {
+  PENDING
+  VERIFIED
+  FAILED
+}
+
 model User {
-  id            String    @id @default(cuid())
-  email         String    @unique
+  id            String       @id @default(cuid())
+  email         String       @unique
   passwordHash  String?
-  emailVerified Boolean   @default(false)
+  emailVerified Boolean      @default(false)
   name          String?
   avatarUrl     String?
-  isActive      Boolean   @default(true)
+  isActive      Boolean      @default(true)
   accounts      Account[]
-  createdAt     DateTime  @default(now())
-  updatedAt     DateTime  @updatedAt
+  createdAt     DateTime     @default(now())
+  updatedAt     DateTime     @updatedAt
   website       Website[]
+  statusPages   StatusPage[]
 
   @@index([email])
 }
@@ -53,14 +60,55 @@ model EmailVerificationToken {
 }
 
 model Website {
-  id        String   @id @default(cuid())
-  url       String
-  name      String?
-  isActive  Boolean  @default(true)
-  userId    String
-  user      User     @relation(fields: [userId], references: [id], onDelete: Cascade)
-  createdAt DateTime @default(now())
-  updatedAt DateTime @updatedAt
+  id                 String              @id @default(cuid())
+  url                String
+  name               String?
+  isActive           Boolean             @default(true)
+  userId             String
+  user               User                @relation(fields: [userId], references: [id], onDelete: Cascade)
+  createdAt          DateTime            @default(now())
+  updatedAt          DateTime            @updatedAt
+  statusPageMonitors StatusPageMonitor[]
 
   @@index([userId])
+}
+
+model StatusPage {
+  id          String              @id @default(cuid())
+  name        String
+  slug        String              @unique
+  isPublished Boolean             @default(true)
+  userId      String
+  user        User                @relation(fields: [userId], references: [id], onDelete: Cascade)
+  monitors    StatusPageMonitor[]
+  domain      StatusPageDomain?
+  createdAt   DateTime            @default(now())
+  updatedAt   DateTime            @updatedAt
+
+  @@index([userId])
+}
+
+model StatusPageMonitor {
+  statusPageId String
+  websiteId    String
+  createdAt    DateTime   @default(now())
+  statusPage   StatusPage @relation(fields: [statusPageId], references: [id], onDelete: Cascade)
+  website      Website    @relation(fields: [websiteId], references: [id], onDelete: Cascade)
+
+  @@id([statusPageId, websiteId])
+  @@index([websiteId])
+}
+
+model StatusPageDomain {
+  id                 String                         @id @default(cuid())
+  statusPageId       String                         @unique
+  hostname           String                         @unique
+  verificationToken  String
+  verificationStatus StatusDomainVerificationStatus @default(PENDING)
+  verifiedAt         DateTime?
+  createdAt          DateTime                       @default(now())
+  updatedAt          DateTime                       @updatedAt
+  statusPage         StatusPage                     @relation(fields: [statusPageId], references: [id], onDelete: Cascade)
+
+  @@index([verificationStatus])
 }

--- a/packages/validators/src/__tests__/status-domain.test.ts
+++ b/packages/validators/src/__tests__/status-domain.test.ts
@@ -1,0 +1,50 @@
+import { describe, it, expect } from "vitest";
+import {
+  canIssueTlsInput,
+  requestStatusDomainVerificationInput,
+  verifyStatusDomainInput,
+} from "../status-domain/index.js";
+
+describe("requestStatusDomainVerificationInput", () => {
+  it("accepts valid payload", () => {
+    const result = requestStatusDomainVerificationInput.safeParse({
+      statusPageId: "sp1",
+      hostname: "status.startup.com",
+    });
+    expect(result.success).toBe(true);
+  });
+
+  it("rejects non-status hostname", () => {
+    const result = requestStatusDomainVerificationInput.safeParse({
+      statusPageId: "sp1",
+      hostname: "app.startup.com",
+    });
+    expect(result.success).toBe(false);
+  });
+});
+
+describe("verifyStatusDomainInput", () => {
+  it("accepts verify payload", () => {
+    const result = verifyStatusDomainInput.safeParse({
+      statusPageId: "sp1",
+      hostname: "status.startup.com",
+    });
+    expect(result.success).toBe(true);
+  });
+});
+
+describe("canIssueTlsInput", () => {
+  it("accepts status hostname", () => {
+    const result = canIssueTlsInput.safeParse({
+      hostname: "status.startup.com",
+    });
+    expect(result.success).toBe(true);
+  });
+
+  it("rejects invalid hostname", () => {
+    const result = canIssueTlsInput.safeParse({
+      hostname: "bad host",
+    });
+    expect(result.success).toBe(false);
+  });
+});

--- a/packages/validators/src/__tests__/status-page.test.ts
+++ b/packages/validators/src/__tests__/status-page.test.ts
@@ -1,0 +1,86 @@
+import { describe, it, expect } from "vitest";
+import {
+  createStatusPageInput,
+  publicStatusPageByHostInput,
+  statusPageHostnameSchema,
+  statusPageSlugSchema,
+  updateStatusPageInput,
+} from "../status-page/index.js";
+
+describe("statusPageSlugSchema", () => {
+  it("accepts valid slugs", () => {
+    expect(statusPageSlugSchema.safeParse("acme-status").success).toBe(true);
+    expect(statusPageSlugSchema.safeParse("status123").success).toBe(true);
+  });
+
+  it("rejects invalid slug formats", () => {
+    expect(statusPageSlugSchema.safeParse("Acme").success).toBe(false);
+    expect(statusPageSlugSchema.safeParse("acme_status").success).toBe(false);
+    expect(statusPageSlugSchema.safeParse("-acme").success).toBe(false);
+  });
+});
+
+describe("statusPageHostnameSchema", () => {
+  it("accepts status-prefixed hostnames", () => {
+    expect(
+      statusPageHostnameSchema.safeParse("status.startup.com").success,
+    ).toBe(true);
+  });
+
+  it("normalizes hostnames to lowercase without trailing dot", () => {
+    const parsed = statusPageHostnameSchema.safeParse("Status.Startup.com.");
+    expect(parsed.success).toBe(true);
+    if (parsed.success) {
+      expect(parsed.data).toBe("status.startup.com");
+    }
+  });
+
+  it("rejects non-status hostnames", () => {
+    expect(statusPageHostnameSchema.safeParse("app.startup.com").success).toBe(
+      false,
+    );
+  });
+});
+
+describe("createStatusPageInput", () => {
+  it("accepts valid payload", () => {
+    const result = createStatusPageInput.safeParse({
+      name: "Acme Status",
+      slug: "acme-status",
+      monitorIds: ["w1", "w2"],
+      isPublished: true,
+    });
+    expect(result.success).toBe(true);
+  });
+
+  it("rejects duplicate monitor IDs", () => {
+    const result = createStatusPageInput.safeParse({
+      name: "Acme Status",
+      slug: "acme-status",
+      monitorIds: ["w1", "w1"],
+    });
+    expect(result.success).toBe(false);
+  });
+});
+
+describe("updateStatusPageInput", () => {
+  it("accepts partial updates", () => {
+    const result = updateStatusPageInput.safeParse({
+      id: "sp1",
+      isPublished: false,
+    });
+    expect(result.success).toBe(true);
+  });
+});
+
+describe("publicStatusPageByHostInput", () => {
+  it("defaults viewMode to per-check", () => {
+    const result = publicStatusPageByHostInput.safeParse({
+      hostname: "status.startup.com",
+    });
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data.viewMode).toBe("per-check");
+    }
+  });
+});

--- a/packages/validators/src/index.ts
+++ b/packages/validators/src/index.ts
@@ -1,2 +1,4 @@
 export * from "./user/index.js";
 export * from "./website/index.js";
+export * from "./status-page/index.js";
+export * from "./status-domain/index.js";

--- a/packages/validators/src/status-domain/index.ts
+++ b/packages/validators/src/status-domain/index.ts
@@ -1,0 +1,50 @@
+import { z } from "zod";
+import {
+  statusDomainVerificationStatusSchema,
+  statusPageHostnameSchema,
+} from "../status-page/index.js";
+
+const statusPageDomainIdentityInput = z
+  .object({
+    statusPageId: z.string().min(1, "Status page ID is required"),
+    hostname: statusPageHostnameSchema,
+  })
+  .strict();
+
+export const requestStatusDomainVerificationInput =
+  statusPageDomainIdentityInput;
+
+export const requestStatusDomainVerificationOutput = z.object({
+  statusPageId: z.string(),
+  hostname: z.string(),
+  verificationStatus: statusDomainVerificationStatusSchema,
+  cnameRecordName: z.string(),
+  cnameRecordValue: z.string(),
+  txtRecordName: z.string(),
+  txtRecordValue: z.string(),
+});
+
+export const verifyStatusDomainInput = statusPageDomainIdentityInput;
+
+export const verifyStatusDomainOutput = z.object({
+  statusPageId: z.string(),
+  hostname: z.string(),
+  verificationStatus: statusDomainVerificationStatusSchema,
+  txtVerified: z.boolean(),
+  cnameVerified: z.boolean(),
+  cnameRecordName: z.string(),
+  cnameRecordValue: z.string(),
+  txtRecordName: z.string(),
+  txtRecordValue: z.string(),
+  verifiedAt: z.date().nullable(),
+});
+
+export const canIssueTlsInput = z
+  .object({
+    hostname: statusPageHostnameSchema,
+  })
+  .strict();
+
+export const canIssueTlsOutput = z.object({
+  allowed: z.boolean(),
+});

--- a/packages/validators/src/status-page/index.ts
+++ b/packages/validators/src/status-page/index.ts
@@ -1,0 +1,131 @@
+import { z } from "zod";
+import { websiteStatusOutput } from "../website/index.js";
+
+const slugRegex = /^[a-z0-9]+(?:-[a-z0-9]+)*$/;
+const hostnameRegex =
+  /^(?=.{4,253}$)(?:[a-z0-9](?:[a-z0-9-]{0,61}[a-z0-9])?\.)+[a-z]{2,63}\.?$/i;
+
+const normalizeHostname = (hostname: string): string =>
+  hostname.trim().toLowerCase().replace(/\.$/, "");
+
+export const statusPageSlugSchema = z
+  .string()
+  .trim()
+  .min(2, "Slug must be at least 2 characters long")
+  .max(63, "Slug must be 63 characters or less")
+  .regex(
+    slugRegex,
+    "Slug can only contain lowercase letters, numbers, and hyphens",
+  );
+
+export const statusPageHostnameSchema = z
+  .string()
+  .trim()
+  .min(1, "Hostname is required")
+  .transform(normalizeHostname)
+  .refine((hostname) => hostnameRegex.test(hostname), {
+    message: "Invalid hostname format",
+  })
+  .refine((hostname) => hostname.startsWith("status."), {
+    message: "Hostname must start with status.",
+  });
+
+export const statusDomainVerificationStatusSchema = z.enum([
+  "PENDING",
+  "VERIFIED",
+  "FAILED",
+]);
+
+const monitorIdsSchema = z
+  .array(z.string().min(1, "Monitor ID is required"))
+  .min(1, "Select at least one monitor")
+  .max(100, "A status page can include at most 100 monitors")
+  .refine((ids) => new Set(ids).size === ids.length, {
+    message: "Monitor IDs must be unique",
+  });
+
+export const statusPageIdInput = z.object({
+  id: z.string().min(1, "Status page ID is required"),
+});
+
+export const createStatusPageInput = z
+  .object({
+    name: z
+      .string()
+      .trim()
+      .min(1, "Name is required")
+      .max(120, "Name must be 120 characters or less"),
+    slug: statusPageSlugSchema,
+    monitorIds: monitorIdsSchema,
+    isPublished: z.boolean().optional(),
+  })
+  .strict();
+
+export const updateStatusPageInput = z
+  .object({
+    id: z.string().min(1, "Status page ID is required"),
+    name: z
+      .string()
+      .trim()
+      .min(1, "Name is required")
+      .max(120, "Name must be 120 characters or less")
+      .optional(),
+    slug: statusPageSlugSchema.optional(),
+    monitorIds: monitorIdsSchema.optional(),
+    isPublished: z.boolean().optional(),
+  })
+  .strict();
+
+export const websiteStatusViewModeInput = z.object({
+  viewMode: z.enum(["per-check", "per-day"]).default("per-check"),
+});
+
+export const publicStatusPageByHostInput = z.object({
+  hostname: statusPageHostnameSchema,
+  viewMode: z.enum(["per-check", "per-day"]).default("per-check"),
+});
+
+export const statusPageDomainOutput = z.object({
+  id: z.string(),
+  hostname: z.string(),
+  verificationStatus: statusDomainVerificationStatusSchema,
+  verifiedAt: z.date().nullable(),
+  createdAt: z.date(),
+  updatedAt: z.date(),
+});
+
+export const statusPageOutput = z.object({
+  id: z.string(),
+  name: z.string(),
+  slug: z.string(),
+  isPublished: z.boolean(),
+  userId: z.string(),
+  monitorCount: z.number().int().nonnegative(),
+  domain: statusPageDomainOutput.nullable(),
+  createdAt: z.date(),
+  updatedAt: z.date(),
+});
+
+export const statusPageListOutput = z.object({
+  statusPages: z.array(statusPageOutput),
+});
+
+export const statusPagePublicOutput = z.object({
+  statusPage: z.object({
+    id: z.string(),
+    name: z.string(),
+    slug: z.string(),
+    hostname: z.string(),
+    websites: z.array(websiteStatusOutput),
+  }),
+});
+
+export type StatusDomainVerificationStatus = z.infer<
+  typeof statusDomainVerificationStatusSchema
+>;
+export type StatusPageIdInput = z.infer<typeof statusPageIdInput>;
+export type CreateStatusPageInput = z.infer<typeof createStatusPageInput>;
+export type UpdateStatusPageInput = z.infer<typeof updateStatusPageInput>;
+export type PublicStatusPageByHostInput = z.infer<
+  typeof publicStatusPageByHostInput
+>;


### PR DESCRIPTION
Fixes #88 

- add status page CRUD with monitor selection and DNS verification flow
- implement public status page rendering with real-time monitor status from ClickHouse
- add Caddy on-demand TLS integration with `/api/tls/ask` endpoint for verified domains
- create middleware rewrite for custom status hostnames (`status.*.com`)
- add comprehensive tRPC procedures, Prisma schema, and Zod validators