### PR TITLE
PublicStatusOverview layout improved

### DIFF
--- a/apps/client/app/(no-navbar)/layout.tsx
+++ b/apps/client/app/(no-navbar)/layout.tsx
@@ -1,4 +1,4 @@
-import Footer from "@/components/ui/Footer";
+
 
 export default function NoNavbarLayout({
   children,
@@ -8,7 +8,6 @@ export default function NoNavbarLayout({
   return (
     <>
       <main className="min-h-screen">{children}</main>
-      <Footer />
     </>
   );
 }

--- a/apps/client/app/components/status/PublicStatusOverview.tsx
+++ b/apps/client/app/components/status/PublicStatusOverview.tsx
@@ -141,95 +141,97 @@ export function PublicStatusOverview({ hostname }: PublicStatusOverviewProps) {
   }
 
   return (
-    <div className="mx-auto w-full max-w-5xl px-4 pb-16 pt-20">
-      {statusQuery.isLoading ? (
-        <div className="rounded-xl border border-border bg-card p-6 text-card-foreground">
-          Loading public status page...
-        </div>
-      ) : statusQuery.isError ? (
-        <div className="rounded-xl border border-destructive/30 bg-destructive/5 p-6 text-destructive">
-          <div className="flex items-center gap-2 text-base font-medium">
-            <AlertCircle className="size-4" />
-            Unable to load status page
+    <div className="relative">
+      <div className="absolute right-4 top-4 z-50">
+        <ThemeToggler className="rounded-full border border-border bg-card p-2 shadow-sm hover:bg-muted transition-colors" />
+      </div>
+      <div className="mx-auto w-full max-w-5xl px-4 pb-16 pt-20">
+        {statusQuery.isLoading ? (
+          <div className="rounded-xl border border-border bg-card p-6 text-card-foreground">
+            Loading public status page...
           </div>
-          <p className="mt-2 text-sm">
-            {getErrorMessage(statusQuery.error) ||
-              "This status page is unavailable."}
-          </p>
-        </div>
-      ) : !statusQuery.data ? (
-        <div className="rounded-xl border border-border bg-card p-6 text-card-foreground">
-          Status page not found.
-        </div>
-      ) : (
-        <>
-          <div className="mb-8 rounded-2xl border border-border bg-card p-6 text-card-foreground flex items-center justify-between">
-            <div>
-              <h1 className="text-3xl font-bold tracking-tight">
-                {statusQuery.data.statusPage.name}
-              </h1>
-              <p className="mt-2 text-sm text-muted-foreground">
-                Live status for <span className="font-medium">{hostname}</span>
-              </p>
+        ) : statusQuery.isError ? (
+          <div className="rounded-xl border border-destructive/30 bg-destructive/5 p-6 text-destructive">
+            <div className="flex items-center gap-2 text-base font-medium">
+              <AlertCircle className="size-4" />
+              Unable to load status page
             </div>
-            <div>
-              <ThemeToggler />
-            </div>
+            <p className="mt-2 text-sm">
+              {getErrorMessage(statusQuery.error) ||
+                "This status page is unavailable."}
+            </p>
           </div>
-
-          <div className="space-y-6">
-            {statusQuery.data.statusPage.websites.length === 0 ? (
-              <div className="rounded-xl border border-border bg-card p-6 text-sm text-muted-foreground">
-                No monitors are currently attached to this status page.
+        ) : !statusQuery.data ? (
+          <div className="rounded-xl border border-border bg-card p-6 text-card-foreground">
+            Status page not found.
+          </div>
+        ) : (
+          <>
+            <div className="mb-8 rounded-2xl border border-border bg-card p-6 text-card-foreground flex items-center justify-between">
+              <div>
+                <h1 className="text-3xl font-bold tracking-tight">
+                  {statusQuery.data.statusPage.name}
+                </h1>
+                <p className="mt-2 text-sm text-muted-foreground">
+                  Live status for <span className="font-medium">{hostname}</span>
+                </p>
               </div>
-            ) : (
-              statusQuery.data.statusPage.websites.map((website) => (
-                <div
-                  key={website.websiteId}
-                  className="rounded-xl border border-border bg-card p-5 text-card-foreground"
-                >
-                  <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
-                    <div className="min-w-0 flex-1">
-                      <div className="truncate text-base font-semibold">
-                        {website.websiteName || website.websiteUrl}
-                      </div>
-                      <a
-                        href={website.websiteUrl}
-                        target="_blank"
-                        rel="noreferrer"
-                        className="mt-1 inline-flex items-center gap-1 text-sm text-muted-foreground underline underline-offset-4"
-                      >
-                        {website.websiteUrl}
-                        <ExternalLink className="size-3" />
-                      </a>
-                    </div>
-                    <div className="flex-shrink-0 self-end sm:self-center">
-                      {renderStatusBadge(website.currentStatus)}
-                    </div>
-                  </div>
+            </div>
 
-                  <div className="mt-4 space-y-1">
-                    <p className="text-xs text-muted-foreground">
-                      Last 30 checks
-                    </p>
-                    <Tracker
-                      data={buildTrackerData(website.statusPoints)}
-                      hoverEffect={website.statusPoints.length > 0}
-                    />
-                  </div>
+            <div className="space-y-6">
+              {statusQuery.data.statusPage.websites.length === 0 ? (
+                <div className="rounded-xl border border-border bg-card p-6 text-sm text-muted-foreground">
+                  No monitors are currently attached to this status page.
                 </div>
-              ))
-            )}
-          </div>
+              ) : (
+                statusQuery.data.statusPage.websites.map((website) => (
+                  <div
+                    key={website.websiteId}
+                    className="rounded-xl border border-border bg-card p-5 text-card-foreground"
+                  >
+                    <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
+                      <div className="min-w-0 flex-1">
+                        <div className="truncate text-base font-semibold">
+                          {website.websiteName || website.websiteUrl}
+                        </div>
+                        <a
+                          href={website.websiteUrl}
+                          target="_blank"
+                          rel="noreferrer"
+                          className="mt-1 inline-flex items-center gap-1 text-sm text-muted-foreground underline underline-offset-4"
+                        >
+                          {website.websiteUrl}
+                          <ExternalLink className="size-3" />
+                        </a>
+                      </div>
+                      <div className="flex-shrink-0 self-end sm:self-center">
+                        {renderStatusBadge(website.currentStatus)}
+                      </div>
+                    </div>
 
-          <div className="mt-10 text-center text-sm text-muted-foreground">
-            Powered by{" "}
-            <Link href="/" className="underline underline-offset-4">
-              Uptique
-            </Link>
-          </div>
-        </>
-      )}
+                    <div className="mt-4 space-y-1">
+                      <p className="text-xs text-muted-foreground">
+                        Last 30 checks
+                      </p>
+                      <Tracker
+                        data={buildTrackerData(website.statusPoints)}
+                        hoverEffect={website.statusPoints.length > 0}
+                      />
+                    </div>
+                  </div>
+                ))
+              )}
+            </div>
+
+            <div className="mt-10 text-center text-sm text-muted-foreground">
+              Powered by{" "}
+              <Link href="/" className="underline underline-offset-4">
+                Uptique
+              </Link>
+            </div>
+          </>
+        )}
+      </div>
     </div>
   );
 }

--- a/apps/client/app/components/status/PublicStatusOverview.tsx
+++ b/apps/client/app/components/status/PublicStatusOverview.tsx
@@ -4,8 +4,7 @@ import Link from "next/link";
 import { AlertCircle, ExternalLink } from "lucide-react";
 import { trpc } from "@/lib/trpc";
 import { Tracker, type TrackerBlockProps } from "@/components/Tracker";
-import ThemeSwitch from "../ThemeSwitch";
-
+import { ThemeToggler } from "../ui/ThemeToggler";
 interface PublicStatusOverviewProps {
   hostname: string;
 }
@@ -174,7 +173,7 @@ export function PublicStatusOverview({ hostname }: PublicStatusOverviewProps) {
               </p>
             </div>
             <div>
-              <ThemeSwitch />
+              <ThemeToggler />
             </div>
           </div>
 

--- a/apps/client/app/components/status/PublicStatusOverview.tsx
+++ b/apps/client/app/components/status/PublicStatusOverview.tsx
@@ -4,6 +4,7 @@ import Link from "next/link";
 import { AlertCircle, ExternalLink } from "lucide-react";
 import { trpc } from "@/lib/trpc";
 import { Tracker, type TrackerBlockProps } from "@/components/Tracker";
+import ThemeSwitch from "../ThemeSwitch";
 
 interface PublicStatusOverviewProps {
   hostname: string;
@@ -83,16 +84,37 @@ function renderStatusBadge(
 
   const label = currentStatus.status === "UP" ? "Up" : "Down";
   const className =
-    currentStatus.status === "UP"
-      ? "border border-primary-action/30 bg-primary-action/10 text-primary-action"
-      : "border border-destructive/30 bg-destructive/10 text-destructive";
+  currentStatus.status === "UP"
+    ? "rounded-full border border-gray-200 py-1 pl-1 pr-2 dark:border-gray-800"
+    : "bg-destructive/10 text-destructive";
+
+  const dotClass =
+  currentStatus.status === "UP"
+    ? "bg-emerald-600 dark:bg-emerald-500"
+    : "bg-red-600 dark:bg-red-500";
+
+  const dotBgClass =
+  currentStatus.status === "UP"
+    ? "bg-emerald-500/20 dark:bg-emerald-600/20"
+    : "bg-red-500/20 dark:bg-red-600/20";
 
   return (
     <div
-      className={`rounded-full px-3 py-1 text-sm font-medium ${className}`}
+      className={`flex items-center gap-1.5 ${className}`}
       title={`Last check: ${formatStatusTime(currentStatus.checkedAt)}`}
     >
-      {label}
+      <div className="relative size-4 shrink-0">
+        <div
+          className={`absolute inset-[1px] rounded-full ${dotBgClass}`}
+        />
+        <div
+          className={`absolute inset-1 rounded-full ${dotClass}`}
+        />
+      </div>
+
+      <span className="text-xs font-medium">
+        {label}
+      </span>
     </div>
   );
 }
@@ -142,13 +164,18 @@ export function PublicStatusOverview({ hostname }: PublicStatusOverviewProps) {
         </div>
       ) : (
         <>
-          <div className="mb-8 rounded-2xl border border-border bg-card p-6 text-card-foreground">
-            <h1 className="text-3xl font-bold tracking-tight">
-              {statusQuery.data.statusPage.name}
-            </h1>
-            <p className="mt-2 text-sm text-muted-foreground">
-              Live status for <span className="font-medium">{hostname}</span>
-            </p>
+          <div className="mb-8 rounded-2xl border border-border bg-card p-6 text-card-foreground flex items-center justify-between">
+            <div>
+              <h1 className="text-3xl font-bold tracking-tight">
+                {statusQuery.data.statusPage.name}
+              </h1>
+              <p className="mt-2 text-sm text-muted-foreground">
+                Live status for <span className="font-medium">{hostname}</span>
+              </p>
+            </div>
+            <div>
+              <ThemeSwitch />
+            </div>
           </div>
 
           <div className="space-y-6">

--- a/apps/client/app/components/status/PublicStatusOverview.tsx
+++ b/apps/client/app/components/status/PublicStatusOverview.tsx
@@ -204,7 +204,9 @@ export function PublicStatusOverview({ hostname }: PublicStatusOverviewProps) {
                         <ExternalLink className="size-3" />
                       </a>
                     </div>
-                    {renderStatusBadge(website.currentStatus)}
+                    <div className="flex-shrink-0 self-end sm:self-center">
+                      {renderStatusBadge(website.currentStatus)}
+                    </div>
                   </div>
 
                   <div className="mt-4 space-y-1">

--- a/apps/client/app/components/ui/ThemeToggler.tsx
+++ b/apps/client/app/components/ui/ThemeToggler.tsx
@@ -1,0 +1,49 @@
+"use client"
+
+import { useEffect, useState } from "react"
+import { Moon, Sun } from "lucide-react"
+
+import { cx } from "@/lib/utils"
+
+interface ThemeTogglerProps extends React.ComponentPropsWithoutRef<"button"> {}
+
+export const ThemeToggler = ({
+  className,
+  ...props
+}: ThemeTogglerProps) => {
+  const [isDark, setIsDark] = useState(false)
+
+  useEffect(() => {
+    const updateTheme = () => {
+      setIsDark(document.documentElement.classList.contains("dark"))
+    }
+
+    updateTheme()
+
+    const observer = new MutationObserver(updateTheme)
+    observer.observe(document.documentElement, {
+      attributes: true,
+      attributeFilter: ["class"],
+    })
+
+    return () => observer.disconnect()
+  }, [])
+
+  const toggleTheme = () => {
+    const newTheme = !isDark
+    setIsDark(newTheme)
+    document.documentElement.classList.toggle("dark")
+    localStorage.setItem("theme", newTheme ? "dark" : "light")
+  }
+
+  return (
+    <button
+      onClick={toggleTheme}
+      className={cx(className)}
+      {...props}
+    >
+      {isDark ? <Sun /> : <Moon />}
+      <span className="sr-only">Toggle theme</span>
+    </button>
+  )
+}

--- a/apps/client/components.json
+++ b/apps/client/components.json
@@ -18,5 +18,7 @@
     "lib": "@/lib",
     "hooks": "@/hooks"
   },
-  "registries": {}
+  "registries": {
+    "@magicui": "https://magicui.design/r/{name}"
+  }
 }


### PR DESCRIPTION
- removed footer in Status page layout
- Improve Status Up/Down UI in Statuspage
- Added Toggle Theme Switcher in Status page

Fixes issue #93 

desktop view:
<img width="1366" height="546" alt="image" src="https://github.com/user-attachments/assets/fe04b19f-db32-4055-ab78-ec5175cbdd58" />

Mobile View:
<img width="313" height="499" alt="image" src="https://github.com/user-attachments/assets/40eaba29-fdb0-48ef-89f9-62181e204eca" />
